### PR TITLE
New job adapter API

### DIFF
--- a/lib/ood_core/job/adapter.rb
+++ b/lib/ood_core/job/adapter.rb
@@ -8,11 +8,11 @@ module OodCore
       # @abstract Subclass is expected to implement {#submit}
       # @raise [NotImplementedError] if subclass did not define {#submit}
       # @example Submit job template to cluster
-      #   solver_id = job_adapter.submit(script: solver_script)
+      #   solver_id = job_adapter.submit(solver_script)
       #   #=> "1234.server"
       # @example Submit job that depends on previous job
       #   post_id = job_adapter.submit(
-      #     script: post_script,
+      #     post_script,
       #     afterok: solver_id
       #   )
       #   #=> "1235.server"
@@ -27,17 +27,24 @@ module OodCore
       # @param afterany [#to_s, Array<#to_s>] this job may be scheduled for
       #   execution after dependent jobs have terminated
       # @return [String] the job id returned after successfully submitting a job
-      def submit(script:, after: [], afterok: [], afternotok: [], afterany: [])
+      def submit(script, after: [], afterok: [], afternotok: [], afterany: [])
         raise NotImplementedError, "subclass did not define #submit"
+      end
+
+      # Retrieve info for all jobs from the resource manager
+      # @abstract Subclass is expected to implement {#info_all}
+      # @raise [NotImplementedError] if subclass did not define {#info_all}
+      # @return [Array<Info>] information describing submitted jobs
+      def info_all
+        raise NotImplementedError, "subclass did not define #info_all"
       end
 
       # Retrieve job info from the resource manager
       # @abstract Subclass is expected to implement {#info}
       # @raise [NotImplementedError] if subclass did not define {#info}
-      # @param id [#to_s] the id of the job, otherwise get list of all jobs
-      #   running on cluster
-      # @return [Info, Array<Info>] information describing submitted job
-      def info(id: '')
+      # @param id [#to_s] the id of the job
+      # @return [Info] information describing submitted job
+      def info(id)
         raise NotImplementedError, "subclass did not define #info"
       end
 
@@ -47,7 +54,7 @@ module OodCore
       # @raise [NotImplementedError] if subclass did not define {#status}
       # @param id [#to_s] the id of the job
       # @return [Status] status of job
-      def status(id:)
+      def status(id)
         raise NotImplementedError, "subclass did not define #status"
       end
 
@@ -56,7 +63,7 @@ module OodCore
       # @raise [NotImplementedError] if subclass did not define {#hold}
       # @param id [#to_s] the id of the job
       # @return [void]
-      def hold(id:)
+      def hold(id)
         raise NotImplementedError, "subclass did not define #hold"
       end
 
@@ -65,7 +72,7 @@ module OodCore
       # @raise [NotImplementedError] if subclass did not define {#release}
       # @param id [#to_s] the id of the job
       # @return [void]
-      def release(id:)
+      def release(id)
         raise NotImplementedError, "subclass did not define #release"
       end
 
@@ -74,7 +81,7 @@ module OodCore
       # @raise [NotImplementedError] if subclass did not define {#delete}
       # @param id [#to_s] the id of the job
       # @return [void]
-      def delete(id:)
+      def delete(id)
         raise NotImplementedError, "subclass did not define #delete"
       end
     end

--- a/lib/ood_core/job/adapters/slurm.rb
+++ b/lib/ood_core/job/adapters/slurm.rb
@@ -234,7 +234,7 @@ module OodCore
         # @return [String] the job id returned after successfully submitting a
         #   job
         # @see Adapter#submit
-        def submit(script:, after: [], afterok: [], afternotok: [], afterany: [])
+        def submit(script, after: [], afterok: [], afternotok: [], afterany: [])
           after      = Array(after).map(&:to_s)
           afterok    = Array(afterok).map(&:to_s)
           afternotok = Array(afternotok).map(&:to_s)
@@ -292,43 +292,35 @@ module OodCore
           raise JobAdapterError, e.message
         end
 
-        # Retrieve job info from the resource manager
-        # @param id [#to_s] the id of the job, otherwise get list of all jobs
-        #   running on cluster
+        # Retrieve info for all jobs from the resource manager
         # @raise [JobAdapterError] if something goes wrong getting job info
-        # @return [Info, Array<Info>] information describing submitted job
+        # @return [Array<Info>] information describing submitted jobs
+        # @see Adapter#info_all
+        def info_all
+          @slurm.get_jobs.map do |v|
+            parse_job_info(v)
+          end
+        rescue Batch::Error => e
+          raise JobAdapterError, e.message
+        end
+
+        # Retrieve job info from the resource manager
+        # @param id [#to_s] the id of the job
+        # @raise [JobAdapterError] if something goes wrong getting job info
+        # @return [Info] information describing submitted job
         # @see Adapter#info
-        def info(id: "")
+        def info(id)
           id = id.to_s
           info_ary = @slurm.get_jobs(id: id).map do |v|
-            allocated_nodes = parse_nodes(v[:node_list])
-            Info.new(
-              id: v[:job_id],
-              status: get_state(v[:state_compact]),
-              allocated_nodes: allocated_nodes,
-              submit_host: nil,
-              job_name: v[:job_name],
-              job_owner: v[:user],
-              accounting_id: v[:account],
-              procs: v[:cpus],
-              queue_name: v[:partition],
-              wallclock_time: duration_in_seconds(v[:time_used]),
-              cpu_time: nil,
-              submission_time: Time.parse(v[:submit_time]),
-              dispatch_time: v[:start_time] == "N/A" ? nil : Time.parse(v[:start_time]),
-              native: v
-            )
+            parse_job_info(v)
           end
-          if !id.empty?
-            # A job id can return multiple jobs if it corresponds to a job
-            # array id, so we need to find the job that corresponds to the
-            # given job id (if we can't find it, we assume it has completed)
-            info_ary.detect( -> { Info.new(id: id, status: :completed) } ) do |info|
-              # Match the job id or the formatted job & task id "1234_0"
-              info.id == id || info.native[:array_job_task_id] == id
-            end
-          else
-            info_ary
+
+          # A job id can return multiple jobs if it corresponds to a job
+          # array id, so we need to find the job that corresponds to the
+          # given job id (if we can't find it, we assume it has completed)
+          info_ary.detect( -> { Info.new(id: id, status: :completed) } ) do |info|
+            # Match the job id or the formatted job & task id "1234_0"
+            info.id == id || info.native[:array_job_task_id] == id
           end
         rescue Batch::Error => e
           raise JobAdapterError, e.message
@@ -339,7 +331,7 @@ module OodCore
         # @raise [JobAdapterError] if something goes wrong getting job status
         # @return [Status] status of job
         # @see Adapter#status
-        def status(id:)
+        def status(id)
           id = id.to_s
           jobs = @slurm.get_jobs(
             id: id,
@@ -365,7 +357,7 @@ module OodCore
         # @raise [JobAdapterError] if something goes wrong holding a job
         # @return [void]
         # @see Adapter#hold
-        def hold(id:)
+        def hold(id)
           @slurm.hold_job(id.to_s)
         rescue Batch::Error => e
           raise JobAdapterError, e.message
@@ -376,7 +368,7 @@ module OodCore
         # @raise [JobAdapterError] if something goes wrong releasing a job
         # @return [void]
         # @see Adapter#release
-        def release(id:)
+        def release(id)
           @slurm.release_job(id.to_s)
         rescue Batch::Error => e
           raise JobAdapterError, e.message
@@ -387,7 +379,7 @@ module OodCore
         # @raise [JobAdapterError] if something goes wrong deleting a job
         # @return [void]
         # @see Adapter#delete
-        def delete(id:)
+        def delete(id)
           @slurm.delete_job(id.to_s)
         rescue Batch::Error => e
           raise JobAdapterError, e.message
@@ -430,6 +422,27 @@ module OodCore
           # Determine state from Slurm state code
           def get_state(st)
             STATE_MAP.fetch(st, :undetermined)
+          end
+
+          # Parse hash describing Slurm job status
+          def parse_job_info(v)
+            allocated_nodes = parse_nodes(v[:node_list])
+            Info.new(
+              id: v[:job_id],
+              status: get_state(v[:state_compact]),
+              allocated_nodes: allocated_nodes,
+              submit_host: nil,
+              job_name: v[:job_name],
+              job_owner: v[:user],
+              accounting_id: v[:account],
+              procs: v[:cpus],
+              queue_name: v[:partition],
+              wallclock_time: duration_in_seconds(v[:time_used]),
+              cpu_time: nil,
+              submission_time: Time.parse(v[:submit_time]),
+              dispatch_time: v[:start_time] == "N/A" ? nil : Time.parse(v[:start_time]),
+              native: v
+            )
           end
       end
     end

--- a/spec/job/adapter_spec.rb
+++ b/spec/job/adapter_spec.rb
@@ -1,15 +1,16 @@
 require "spec_helper"
 
 describe OodCore::Job::Adapter do
-  it { is_expected.to respond_to(:submit).with(0).arguments.and_keywords(:script, :after, :afterok, :afternotok, :afterany) }
-  it { is_expected.to respond_to(:info).with(0).arguments.and_keywords(:id) }
-  it { is_expected.to respond_to(:status).with(0).arguments.and_keywords(:id) }
-  it { is_expected.to respond_to(:hold).with(0).arguments.and_keywords(:id) }
-  it { is_expected.to respond_to(:release).with(0).arguments.and_keywords(:id) }
-  it { is_expected.to respond_to(:delete).with(0).arguments.and_keywords(:id) }
+  it { is_expected.to respond_to(:submit).with(1).argument.and_keywords(:after, :afterok, :afternotok, :afterany) }
+  it { is_expected.to respond_to(:info_all).with(0).arguments }
+  it { is_expected.to respond_to(:info).with(1).argument }
+  it { is_expected.to respond_to(:status).with(1).argument }
+  it { is_expected.to respond_to(:hold).with(1).argument }
+  it { is_expected.to respond_to(:release).with(1).argument }
+  it { is_expected.to respond_to(:delete).with(1).argument }
 
   describe "#submit" do
-    context "when :script not defined" do
+    context "when script not defined" do
       it "raises ArgumentError" do
         expect { subject.submit }.to raise_error(ArgumentError)
       end
@@ -17,14 +18,26 @@ describe OodCore::Job::Adapter do
 
     context "when valid arguments" do
       it "raises NotImplementedError" do
-        expect { subject.submit script: "script" }.to raise_error(NotImplementedError)
+        expect { subject.submit "script" }.to raise_error(NotImplementedError)
       end
     end
   end
 
-  describe "#info" do
+  describe "#info_all" do
     it "raises NotImplementedError" do
-      expect { subject.info }.to raise_error(NotImplementedError)
+      expect { subject.info_all }.to raise_error(NotImplementedError)
+    end
+  end
+
+  describe "#info" do
+    context "when id not defined" do
+      it "raises ArgumentError" do
+        expect { subject.info }.to raise_error(ArgumentError)
+      end
+    end
+
+    it "raises NotImplementedError" do
+      expect { subject.info "id" }.to raise_error(NotImplementedError)
     end
   end
 
@@ -37,7 +50,7 @@ describe OodCore::Job::Adapter do
 
     context "when valid arguments" do
       it "raises NotImplementedError" do
-        expect { subject.status id: "id" }.to raise_error(NotImplementedError)
+        expect { subject.status "id" }.to raise_error(NotImplementedError)
       end
     end
   end
@@ -51,7 +64,7 @@ describe OodCore::Job::Adapter do
 
     context "when valid arguments" do
       it "raises NotImplementedError" do
-        expect { subject.hold id: "id" }.to raise_error(NotImplementedError)
+        expect { subject.hold "id" }.to raise_error(NotImplementedError)
       end
     end
   end
@@ -65,7 +78,7 @@ describe OodCore::Job::Adapter do
 
     context "when valid arguments" do
       it "raises NotImplementedError" do
-        expect { subject.release id: "id" }.to raise_error(NotImplementedError)
+        expect { subject.release "id" }.to raise_error(NotImplementedError)
       end
     end
   end
@@ -79,7 +92,7 @@ describe OodCore::Job::Adapter do
 
     context "when valid arguments" do
       it "raises NotImplementedError" do
-        expect { subject.delete id: "id" }.to raise_error(NotImplementedError)
+        expect { subject.delete "id" }.to raise_error(NotImplementedError)
       end
     end
   end

--- a/spec/job/adapters/slurm_spec.rb
+++ b/spec/job/adapters/slurm_spec.rb
@@ -8,12 +8,13 @@ describe OodCore::Job::Adapters::Slurm do
   # Subject
   subject(:adapter) { described_class.new(slurm: slurm) }
 
-  it { is_expected.to respond_to(:submit).with(0).arguments.and_keywords(:script, :after, :afterok, :afternotok, :afterany) }
-  it { is_expected.to respond_to(:info).with(0).arguments.and_keywords(:id) }
-  it { is_expected.to respond_to(:status).with(0).arguments.and_keywords(:id) }
-  it { is_expected.to respond_to(:hold).with(0).arguments.and_keywords(:id) }
-  it { is_expected.to respond_to(:release).with(0).arguments.and_keywords(:id) }
-  it { is_expected.to respond_to(:delete).with(0).arguments.and_keywords(:id) }
+  it { is_expected.to respond_to(:submit).with(1).argument.and_keywords(:after, :afterok, :afternotok, :afterany) }
+  it { is_expected.to respond_to(:info_all).with(0).arguments }
+  it { is_expected.to respond_to(:info).with(1).argument }
+  it { is_expected.to respond_to(:status).with(1).argument }
+  it { is_expected.to respond_to(:hold).with(1).argument }
+  it { is_expected.to respond_to(:release).with(1).argument }
+  it { is_expected.to respond_to(:delete).with(1).argument }
 
   describe ".new" do
     context "when :slurm not defined" do
@@ -37,13 +38,13 @@ describe OodCore::Job::Adapters::Slurm do
     let(:slurm) { double(submit_string: "job.123") }
     let(:content) { "my batch script" }
 
-    context "when :script not defined" do
+    context "when script not defined" do
       it "raises ArgumentError" do
         expect { adapter.submit }.to raise_error(ArgumentError)
       end
     end
 
-    subject { adapter.submit(script: build_script) }
+    subject { adapter.submit(build_script) }
 
     it "returns job id" do
       is_expected.to eq("job.123")
@@ -51,26 +52,26 @@ describe OodCore::Job::Adapters::Slurm do
     end
 
     context "with :queue_name" do
-      before { adapter.submit(script: build_script(queue_name: "queue")) }
+      before { adapter.submit(build_script(queue_name: "queue")) }
 
       it { expect(slurm).to have_received(:submit_string).with(content, args: ["-p", "queue"], env: {}) }
     end
 
     context "with :args" do
-      before { adapter.submit(script: build_script(args: ["arg1", "arg2"])) }
+      before { adapter.submit(build_script(args: ["arg1", "arg2"])) }
 
       it { expect(slurm).to have_received(:submit_string).with(content, args: [], env: {}) }
     end
 
     context "with :submit_as_hold" do
       context "as true" do
-        before { adapter.submit(script: build_script(submit_as_hold: true)) }
+        before { adapter.submit(build_script(submit_as_hold: true)) }
 
         it { expect(slurm).to have_received(:submit_string).with(content, args: ["-H"], env: {}) }
       end
 
       context "as false" do
-        before { adapter.submit(script: build_script(submit_as_hold: false)) }
+        before { adapter.submit(build_script(submit_as_hold: false)) }
 
         it { expect(slurm).to have_received(:submit_string).with(content, args: [], env: {}) }
       end
@@ -78,45 +79,45 @@ describe OodCore::Job::Adapters::Slurm do
 
     context "with :rerunnable" do
       context "as true" do
-        before { adapter.submit(script: build_script(rerunnable: true)) }
+        before { adapter.submit(build_script(rerunnable: true)) }
 
         it { expect(slurm).to have_received(:submit_string).with(content, args: ["--requeue"], env: {}) }
       end
 
       context "as false" do
-        before { adapter.submit(script: build_script(rerunnable: false)) }
+        before { adapter.submit(build_script(rerunnable: false)) }
 
         it { expect(slurm).to have_received(:submit_string).with(content, args: ["--no-requeue"], env: {}) }
       end
     end
 
     context "with :job_environment" do
-      before { adapter.submit(script: build_script(job_environment: {"key" => "value"})) }
+      before { adapter.submit(build_script(job_environment: {"key" => "value"})) }
 
       it { expect(slurm).to have_received(:submit_string).with(content, args: ["--export", "key"], env: {"key" => "value"}) }
     end
 
     context "with :workdir" do
-      before { adapter.submit(script: build_script(workdir: "/path/to/workdir")) }
+      before { adapter.submit(build_script(workdir: "/path/to/workdir")) }
 
       it { expect(slurm).to have_received(:submit_string).with(content, args: ["-D", "/path/to/workdir"], env: {}) }
     end
 
     context "with :email" do
-      before { adapter.submit(script: build_script(email: ["email1", "email2"])) }
+      before { adapter.submit(build_script(email: ["email1", "email2"])) }
 
       it { expect(slurm).to have_received(:submit_string).with(content, args: ["--mail-user", "email1,email2"], env: {}) }
     end
 
     context "with :email_on_started" do
       context "as true" do
-        before { adapter.submit(script: build_script(email_on_started: true)) }
+        before { adapter.submit(build_script(email_on_started: true)) }
 
         it { expect(slurm).to have_received(:submit_string).with(content, args: ["--mail-type", "BEGIN"], env: {}) }
       end
 
       context "as false" do
-        before { adapter.submit(script: build_script(email_on_started: false)) }
+        before { adapter.submit(build_script(email_on_started: false)) }
 
         it { expect(slurm).to have_received(:submit_string).with(content, args: [], env: {}) }
       end
@@ -124,133 +125,133 @@ describe OodCore::Job::Adapters::Slurm do
 
     context "with :email_on_terminated" do
       context "as true" do
-        before { adapter.submit(script: build_script(email_on_terminated: true)) }
+        before { adapter.submit(build_script(email_on_terminated: true)) }
 
         it { expect(slurm).to have_received(:submit_string).with(content, args: ["--mail-type", "END"], env: {}) }
       end
 
       context "as false" do
-        before { adapter.submit(script: build_script(email_on_terminated: false)) }
+        before { adapter.submit(build_script(email_on_terminated: false)) }
 
         it { expect(slurm).to have_received(:submit_string).with(content, args: [], env: {}) }
       end
     end
 
     context "with :email_on_started and :email_on_terminated" do
-      before { adapter.submit(script: build_script(email_on_started: true, email_on_terminated: true)) }
+      before { adapter.submit(build_script(email_on_started: true, email_on_terminated: true)) }
 
       it { expect(slurm).to have_received(:submit_string).with(content, args: ["--mail-type", "ALL"], env: {}) }
     end
 
     context "with :job_name" do
-      before { adapter.submit(script: build_script(job_name: "my_job")) }
+      before { adapter.submit(build_script(job_name: "my_job")) }
 
       it { expect(slurm).to have_received(:submit_string).with(content, args: ["-J", "my_job"], env: {}) }
     end
 
     context "with :input_path" do
-      before { adapter.submit(script: build_script(input_path: "/path/to/input")) }
+      before { adapter.submit(build_script(input_path: "/path/to/input")) }
 
       it { expect(slurm).to have_received(:submit_string).with(content, args: ["-i", Pathname.new("/path/to/input")], env: {}) }
     end
 
     context "with :output_path" do
-      before { adapter.submit(script: build_script(output_path: "/path/to/output")) }
+      before { adapter.submit(build_script(output_path: "/path/to/output")) }
 
       it { expect(slurm).to have_received(:submit_string).with(content, args: ["-o", Pathname.new("/path/to/output")], env: {}) }
     end
 
     context "with :error_path" do
-      before { adapter.submit(script: build_script(error_path: "/path/to/error")) }
+      before { adapter.submit(build_script(error_path: "/path/to/error")) }
 
       it { expect(slurm).to have_received(:submit_string).with(content, args: ["-e", Pathname.new("/path/to/error")], env: {}) }
     end
 
     context "with :join_files" do
       context "as true" do
-        before { adapter.submit(script: build_script(join_files: true)) }
+        before { adapter.submit(build_script(join_files: true)) }
 
         it { expect(slurm).to have_received(:submit_string).with(content, args: [], env: {}) }
       end
 
       context "as false" do
-        before { adapter.submit(script: build_script(join_files: false)) }
+        before { adapter.submit(build_script(join_files: false)) }
 
         it { expect(slurm).to have_received(:submit_string).with(content, args: [], env: {}) }
       end
     end
 
     context "with :reservation_id" do
-      before { adapter.submit(script: build_script(reservation_id: "my_rsv")) }
+      before { adapter.submit(build_script(reservation_id: "my_rsv")) }
 
       it { expect(slurm).to have_received(:submit_string).with(content, args: ["--reservation", "my_rsv"], env: {}) }
     end
 
     context "with :priority" do
-      before { adapter.submit(script: build_script(priority: 123)) }
+      before { adapter.submit(build_script(priority: 123)) }
 
       it { expect(slurm).to have_received(:submit_string).with(content, args: ["--priority", 123], env: {}) }
     end
 
     context "with :start_time" do
-      before { adapter.submit(script: build_script(start_time: Time.new(2016, 11, 8, 13, 53, 54).to_i)) }
+      before { adapter.submit(build_script(start_time: Time.new(2016, 11, 8, 13, 53, 54).to_i)) }
 
       it { expect(slurm).to have_received(:submit_string).with(content, args: ["--begin", "2016-11-08T13:53:54"], env: {}) }
     end
 
     context "with :accounting_id" do
-      before { adapter.submit(script: build_script(accounting_id: "my_account")) }
+      before { adapter.submit(build_script(accounting_id: "my_account")) }
 
       it { expect(slurm).to have_received(:submit_string).with(content, args: ["-A", "my_account"], env: {}) }
     end
 
     context "with :min_phys_memory" do
-      before { adapter.submit(script: build_script(min_phys_memory: 1234)) }
+      before { adapter.submit(build_script(min_phys_memory: 1234)) }
 
       it { expect(slurm).to have_received(:submit_string).with(content, args: ["--mem", "1234K"], env: {}) }
     end
 
     context "with :wall_time" do
-      before { adapter.submit(script: build_script(wall_time: 94534)) }
+      before { adapter.submit(build_script(wall_time: 94534)) }
 
       it { expect(slurm).to have_received(:submit_string).with(content, args: ["-t", "26:15:34"], env: {}) }
     end
 
     context "with :nodes" do
       context "as single node name" do
-        before { adapter.submit(script: build_script(nodes: "node")) }
+        before { adapter.submit(build_script(nodes: "node")) }
 
         it { expect(slurm).to have_received(:submit_string).with(content, args: [], env: {}) }
       end
 
       context "as single node request object" do
-        before { adapter.submit(script: build_script(nodes: {procs: 12, properties: ["prop1", "prop2"]})) }
+        before { adapter.submit(build_script(nodes: {procs: 12, properties: ["prop1", "prop2"]})) }
 
         it { expect(slurm).to have_received(:submit_string).with(content, args: [], env: {}) }
       end
 
       context "as a list of nodes" do
-        before { adapter.submit(script: build_script(nodes: ["node1"] + [{procs: 12}]*4 + ["node2", {procs: 45, properties: "prop"}])) }
+        before { adapter.submit(build_script(nodes: ["node1"] + [{procs: 12}]*4 + ["node2", {procs: 45, properties: "prop"}])) }
 
         it { expect(slurm).to have_received(:submit_string).with(content, args: [], env: {}) }
       end
     end
 
     context "with :native" do
-      before { adapter.submit(script: build_script(native: ["A", "B", "C"])) }
+      before { adapter.submit(build_script(native: ["A", "B", "C"])) }
 
       it { expect(slurm).to have_received(:submit_string).with(content, args: ["A", "B", "C"], env: {}) }
     end
 
     %i(after afterok afternotok afterany).each do |after|
       context "and :#{after} is defined as a single job id" do
-        before { adapter.submit(script: build_script, after => "job_id") }
+        before { adapter.submit(build_script, after => "job_id") }
 
         it { expect(slurm).to have_received(:submit_string).with(content, args: ["-d", "#{after}:job_id"], env: {}) }
       end
 
       context "and :#{after} is defined as multiple job ids" do
-        before { adapter.submit(script: build_script, after => ["job1", "job2"]) }
+        before { adapter.submit(build_script, after => ["job1", "job2"]) }
 
         it { expect(slurm).to have_received(:submit_string).with(content, args: ["-d", "#{after}:job1:job2"], env: {}) }
       end
@@ -265,21 +266,35 @@ describe OodCore::Job::Adapters::Slurm do
     end
   end
 
-  describe "#info" do
-    context "when :id is not defined" do
-      let(:slurm) { double(get_jobs: {}) }
-      subject { adapter.info }
+  describe "#info_all" do
+    let(:slurm) { double(get_jobs: {}) }
+    subject { adapter.info_all }
 
-      it "returns an array of all the jobs" do
-        is_expected.to eq([])
-        expect(slurm).to have_received(:get_jobs).with(id: "")
+    it "returns an array of all the jobs" do
+      is_expected.to eq([])
+      expect(slurm).to have_received(:get_jobs).with(no_args)
+    end
+
+    context "when OodCore::Job::Adapters::Slurm::Batch::Error is raised" do
+      before { expect(slurm).to receive(:get_jobs).and_raise(OodCore::Job::Adapters::Slurm::Batch::Error) }
+
+      it "raises OodCore::JobAdapterError" do
+        expect { subject }.to raise_error(OodCore::JobAdapterError)
+      end
+    end
+  end
+
+  describe "#info" do
+    context "when id is not defined" do
+      it "raises ArgumentError" do
+        expect { adapter.info }.to raise_error(ArgumentError)
       end
     end
 
     let(:job_id)   { "job_id" }
     let(:job_hash) { {} }
     let(:slurm)    { double(get_jobs: [job_hash]) }
-    subject { adapter.info(id: double(to_s: job_id)) }
+    subject { adapter.info(double(to_s: job_id)) }
 
     context "when job is not running" do
       let(:job_hash) {
@@ -537,7 +552,7 @@ describe OodCore::Job::Adapters::Slurm do
   end
 
   describe "#status" do
-    context "when :id is not defined" do
+    context "when id is not defined" do
       it "raises ArgumentError" do
         expect { adapter.status }.to raise_error(ArgumentError)
       end
@@ -546,7 +561,7 @@ describe OodCore::Job::Adapters::Slurm do
     let(:job_state) { "" }
     let(:job_id)    { "job_id" }
     let(:slurm)     { double(get_jobs: [job_id: job_id, array_job_task_id: job_id, state_compact: job_state]) }
-    subject { adapter.status(id: double(to_s: job_id)) }
+    subject { adapter.status(double(to_s: job_id)) }
 
     it "request only job state from OodCore::Job::Adapters::Slurm::Batch" do
       subject
@@ -706,7 +721,7 @@ describe OodCore::Job::Adapters::Slurm do
   end
 
   describe "#hold" do
-    context "when :id is not defined" do
+    context "when id is not defined" do
       it "raises ArgumentError" do
         expect { adapter.hold }.to raise_error(ArgumentError)
       end
@@ -714,7 +729,7 @@ describe OodCore::Job::Adapters::Slurm do
 
     let(:job_id) { "job_id" }
     let(:slurm)  { double(hold_job: nil) }
-    subject { adapter.hold(id: double(to_s: job_id)) }
+    subject { adapter.hold(double(to_s: job_id)) }
 
     it "holds job using OodCore::Job::Adapters::Slurm::Batch" do
       subject
@@ -731,7 +746,7 @@ describe OodCore::Job::Adapters::Slurm do
   end
 
   describe "#release" do
-    context "when :id is not defined" do
+    context "when id is not defined" do
       it "raises ArgumentError" do
         expect { adapter.release }.to raise_error(ArgumentError)
       end
@@ -739,7 +754,7 @@ describe OodCore::Job::Adapters::Slurm do
 
     let(:job_id) { "job_id" }
     let(:slurm)  { double(release_job: nil) }
-    subject { adapter.release(id: double(to_s: job_id)) }
+    subject { adapter.release(double(to_s: job_id)) }
 
     it "releases job using OodCore::Job::Adapters::Slurm::Batch" do
       subject
@@ -756,7 +771,7 @@ describe OodCore::Job::Adapters::Slurm do
   end
 
   describe "#delete" do
-    context "when :id is not defined" do
+    context "when id is not defined" do
       it "raises ArgumentError" do
         expect { adapter.delete }.to raise_error(ArgumentError)
       end
@@ -764,7 +779,7 @@ describe OodCore::Job::Adapters::Slurm do
 
     let(:job_id) { "job_id" }
     let(:slurm)  { double(delete_job: nil) }
-    subject { adapter.delete(id: double(to_s: job_id)) }
+    subject { adapter.delete(double(to_s: job_id)) }
 
     it "deletes job using OodCore::Job::Adapters::Slurm::Batch" do
       subject


### PR DESCRIPTION
Fixes #12

Also removes keyword args such as `script:` and `id:` as these are always required for the respective methods.