### PR TITLE
Set adapter initializers to private in docs

### DIFF
--- a/lib/ood_core/acl/adapters/group.rb
+++ b/lib/ood_core/acl/adapters/group.rb
@@ -33,9 +33,11 @@ module OodCore
       class Group < Adapter
         using Refinements::HashExtensions
 
+        # @api private
         # @param opts [#to_h] the options defining this adapter
         # @option opts [OodSupport::ACL] :acl The ACL permission
         # @option opts [Boolean] :allow (true) Whether this ACL allows access
+        # @see Factory.build_group
         def initialize(opts)
           o = opts.to_h.symbolize_keys
           @acl = o.fetch(:acl) { raise ArgumentError, "No acl specified. Missing argument: acl" }

--- a/lib/ood_core/job/adapters/slurm.rb
+++ b/lib/ood_core/job/adapters/slurm.rb
@@ -26,6 +26,7 @@ module OodCore
         using Refinements::HashExtensions
 
         # Object used for simplified communication with a Slurm batch server
+        # @api private
         class Batch
           # The cluster of the Slurm batch server
           # @example CHPC's kingspeak cluster
@@ -211,8 +212,10 @@ module OodCore
           'TO' => :completed   # TIMEOUT
         }
 
+        # @api private
         # @param opts [#to_h] the options defining this adapter
         # @option opts [Batch] :slurm The Slurm batch object
+        # @see Factory.build_slurm
         def initialize(opts = {})
           o = opts.to_h.symbolize_keys
 

--- a/lib/ood_core/job/adapters/torque.rb
+++ b/lib/ood_core/job/adapters/torque.rb
@@ -40,8 +40,10 @@ module OodCore
           'C' => :completed
         }
 
+        # @api private
         # @param opts [#to_h] the options defining this adapter
         # @option opts [PBS::Batch] :pbs The PBS batch object
+        # @see Factory.build_torque
         def initialize(opts = {})
           o = opts.to_h.symbolize_keys
 


### PR DESCRIPTION
Set documentation on adapter intializers to private so it keeps it internal.