### PR TITLE
handle LSF 9.1 bjobs output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ Features:
   - added a new Batch Connect template feature that builds batch scripts to
     launch web servers
 
+Bugfixes:
+
+  - fix parsing bjobs output for LSF 9.1, which has extra SLOTS column
+
 ## 0.0.4 (2017-05-17)
 
 Features:

--- a/spec/job/adapters/lsf/batch_spec.rb
+++ b/spec/job/adapters/lsf/batch_spec.rb
@@ -122,6 +122,34 @@ OUTPUT
     end
   end
 
+    it "parses output for one job in LSF 9.1" do
+      output = <<-OUTPUT
+JOBID      USER    STAT  QUEUE      FROM_HOST   EXEC_HOST   JOB_NAME   SUBMIT_TIME  PROJ_NAME CPU_USED MEM SWAP PIDS START_TIME FINISH_TIME SLOTS
+5861085 efranz  RUN   sn_xlong   login5      sx6036-1402 u256-1     06/15-16:48:55 082848040736 165:53:45.00 114    0      17435,17555,17559,17719 06/15-16:48:56 -  1
+      OUTPUT
+      expect(batch.parse_bjobs_output(output)).to eq([{
+        id: "5861085",
+        user: "efranz",
+        status: "RUN",
+        queue: "sn_xlong",
+        from_host: "login5",
+        exec_host: "sx6036-1402",
+        name: "u256-1",
+        submit_time: "06/15-16:48:55",
+        project: "082848040736",
+        cpu_used: "165:53:45.00",
+        mem:"114",
+        swap:"0",
+        pids:"17435,17555,17559,17719",
+        start_time: "06/15-16:48:56",
+        finish_time: nil,
+
+        # FIXME: we omit slots right now to make it easier to deal with both
+        # plus we can calculate the total number of slots in the LSF details pane
+        # slots: "1"
+       }])
+    end
+
   describe "#get_jobs" do
     it "calls bjobs with default args when id not specified" do
       expect(batch).to receive(:call).with("bjobs", *batch.bjobs_default_args)


### PR DESCRIPTION
`bjobs` output 9.1 may include an extra column SLOTS

1. update the bjobs line parsing code to not assume 15 columns but handle a variable number of columns
2. update the bjobs output validation to verity that the output has the expected columns in order, but ignore extra columns

Note:

The current fix has validation that assumes if columns `JOBID USER STAT QUEUE...` appear there will never be new columns before `JOBID` but only after.

This still has the problem that in 8.3 there wasn't a clean way to get the estimated runtime, as there is in 9.1. So the estimated runtime is still current time - start time, and it is accurate only if the job never goes into a suspended state.

For this reason, we should have LSF 9+ users add version: "9.1" to their cluster config.