### PR TITLE
Add helper method to filter jobs by owner

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ Features:
   - added a new Batch Connect template feature that builds batch scripts to
     launch web servers
   - removed deprecated tests for the Slurm adapter
+  - added method to filter list of batch jobs for a given owner
 
 Bugfixes:
 

--- a/lib/ood_core/job/adapter.rb
+++ b/lib/ood_core/job/adapter.rb
@@ -39,6 +39,13 @@ module OodCore
         raise NotImplementedError, "subclass did not define #info_all"
       end
 
+      # Retrieve info for all jobs for a given owner from the resource manager
+      # @param owner [#to_s] the owner of the jobs
+      # @return [Array<Info>] information describing submitted jobs
+      def info_where_owner(owner)
+        info_all.select { |info| info.job_owner == owner.to_s }
+      end
+
       # Retrieve job info from the resource manager
       # @abstract Subclass is expected to implement {#info}
       # @raise [NotImplementedError] if subclass did not define {#info}

--- a/spec/job/adapter_spec.rb
+++ b/spec/job/adapter_spec.rb
@@ -1,8 +1,12 @@
 require "spec_helper"
 
 describe OodCore::Job::Adapter do
+  # Subject
+  subject(:adapter) { described_class.new }
+
   it { is_expected.to respond_to(:submit).with(1).argument.and_keywords(:after, :afterok, :afternotok, :afterany) }
   it { is_expected.to respond_to(:info_all).with(0).arguments }
+  it { is_expected.to respond_to(:info_where_owner).with(1).argument }
   it { is_expected.to respond_to(:info).with(1).argument }
   it { is_expected.to respond_to(:status).with(1).argument }
   it { is_expected.to respond_to(:hold).with(1).argument }
@@ -26,6 +30,28 @@ describe OodCore::Job::Adapter do
   describe "#info_all" do
     it "raises NotImplementedError" do
       expect { subject.info_all }.to raise_error(NotImplementedError)
+    end
+  end
+
+  describe "#info_where_owner" do
+    let(:bob_job) { double("bob", job_owner: "bob") }
+    let(:sam_job) { double("sam", job_owner: "sam") }
+    let(:jon_job) { double("jon", job_owner: "jon") }
+
+    subject { adapter.info_where_owner(owner) }
+
+    before { allow(adapter).to receive(:info_all) { [bob_job, sam_job, bob_job, jon_job] } }
+
+    context "when no jobs with specified owner" do
+      let(:owner) { "nobody" }
+
+      it { is_expected.to eq([]) }
+    end
+
+    context "when jobs exist for specified owner" do
+      let(:owner) { "bob" }
+
+      it { is_expected.to eq([bob_job, bob_job]) }
     end
   end
 


### PR DESCRIPTION
Fixes #26

Changed it from `#info_where_user` to `#info_where_owner` because we defined it in the `Info` object as `#job_owner`.