### PR TITLE
Provide node/procs info if available for non-running jobs in Torque

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ Features:
   - added support for the PBS Professional resource manager
   - removed deprecated tests for the Slurm adapter
   - added method to filter list of batch jobs for a given owner
+  - Torque adapter provides nodes/procs info if available for non-running jobs
 
 Bugfixes:
 

--- a/lib/ood_core/job/adapters/torque.rb
+++ b/lib/ood_core/job/adapters/torque.rb
@@ -238,6 +238,16 @@ module OodCore
           def parse_job_info(k, v)
             /^(?<job_owner>[\w-]+)@/ =~ v[:Job_Owner]
             allocated_nodes = parse_nodes(v[:exec_host] || "")
+            procs = allocated_nodes.inject(0) { |sum, x| sum + x[:procs] }
+            if allocated_nodes.empty?
+              allocated_nodes = [ { name: nil } ] * v.fetch(:Resource_List, {})[:nodect].to_i
+              # Only cover the simplest of cases where there is a single
+              # `ppn=##` and ignore otherwise
+              ppn_list = v.fetch(:Resource_List, {})[:nodes].to_s.scan(/ppn=(\d+)/)
+              if ppn_list.size == 1
+                procs = allocated_nodes.size * ppn_list.first.first.to_i
+              end
+            end
             Info.new(
               id: k,
               status: STATE_MAP.fetch(v[:job_state], :undetermined),
@@ -246,7 +256,7 @@ module OodCore
               job_name: v[:Job_Name],
               job_owner: job_owner,
               accounting_id: v[:Account_Name],
-              procs: allocated_nodes.inject(0) { |sum, x| sum + x[:procs] },
+              procs: procs,
               queue_name: v[:queue],
               wallclock_time: duration_in_seconds(v.fetch(:resources_used, {})[:walltime]),
               wallclock_limit: duration_in_seconds(v.fetch(:Resource_List, {})[:walltime]),

--- a/spec/job/adapters/torque_spec.rb
+++ b/spec/job/adapters/torque_spec.rb
@@ -259,16 +259,22 @@ describe OodCore::Job::Adapters::Torque do
   end
 
   describe "#info" do
-    context "when id is not defined" do
-      it "raises ArgumentError" do
-        expect { adapter.info }.to raise_error(ArgumentError)
-      end
+    def job_info(opts = {})
+      OodCore::Job::Info.new(
+        job_info_hash.merge opts
+      )
     end
 
     let(:job_id)   { "job_id" }
     let(:job_hash) { {} }
     let(:pbs)      { double(get_job: {job_id => job_hash}) }
     subject { adapter.info(double(to_s: job_id)) }
+
+    context "when id is not defined" do
+      it "raises ArgumentError" do
+        expect { adapter.info }.to raise_error(ArgumentError)
+      end
+    end
 
     context "when job is not running" do
       let(:job_hash) {
@@ -291,7 +297,7 @@ describe OodCore::Job::Adapters::Torque do
           :Priority=>"0",
           :qtime=>"1478625456",
           :Rerunable=>"True",
-          :Resource_List=>{:gattr=>"PDS0218", :nodect=>"2", :nodes=>"2:ppn=12", :walltime=>"30:00:00"},
+          :Resource_List=>{:gattr=>"PDS0218", :nodect=>"2", :nodes=>nodes, :walltime=>"30:00:00"},
           :Shell_Path_List=>"/bin/bash",
           :euser=>"cwr0448",
           :egroup=>"PDS0218",
@@ -304,16 +310,19 @@ describe OodCore::Job::Adapters::Torque do
         }
       }
 
-      it "returns correct OodCore::Job::Info object" do
-        is_expected.to eq(OodCore::Job::Info.new(
+      let(:job_info_hash) {
+        {
           :id=>job_id,
           :status=>:queued,
-          :allocated_nodes=>[],
+          :allocated_nodes=>[
+            {:name=>nil},
+            {:name=>nil},
+          ],
           :submit_host=>"oakley02.osc.edu",
           :job_name=>"gromacs_job",
           :job_owner=>"cwr0448",
           :accounting_id=>"PAA0016",
-          :procs=>0,
+          :procs=>24,
           :queue_name=>"parallel",
           :wallclock_time=>0,
           :wallclock_limit=>108000,
@@ -321,7 +330,39 @@ describe OodCore::Job::Adapters::Torque do
           :submission_time=>"1478625456",
           :dispatch_time=>nil,
           :native=>job_hash
-        ))
+        }
+      }
+
+      context "and 2 nodes requested with simple structure" do
+        let(:nodes) { "2:ppn=12" }
+
+        it "returns correct OodCore::Job::Info object with 24 procs" do
+          is_expected.to eq(job_info)
+        end
+      end
+
+      context "and 2 nodes requested with complicated structure" do
+        let(:nodes) { "1:ppn=28+1:ppn=14" }
+
+        it "returns correct OodCore::Job::Info object with 0 procs" do
+          is_expected.to eq(job_info(procs: 0))
+        end
+      end
+
+      context "and 2 nodes requested missing ppn information" do
+        let(:nodes) { "2" }
+
+        it "returns correct OodCore::Job::Info object with 0 procs" do
+          is_expected.to eq(job_info(procs: 0))
+        end
+      end
+
+      context "and 2 nodes requested with extra information" do
+        let(:nodes) { "2:gpus=1:ppn=12:vis" }
+
+        it "returns correct OodCore::Job::Info object with 24 procs" do
+          is_expected.to eq(job_info)
+        end
       end
     end
 
@@ -367,8 +408,8 @@ describe OodCore::Job::Adapters::Torque do
         }
       }
 
-      it "returns correct OodCore::Job::Info object" do
-        is_expected.to eql(OodCore::Job::Info.new(
+      let(:job_info_hash) {
+        {
           :id=>job_id,
           :status=>:running,
           :allocated_nodes=>[
@@ -393,7 +434,11 @@ describe OodCore::Job::Adapters::Torque do
           :submission_time=>"1474895720",
           :dispatch_time=>"1478612793",
           :native=>job_hash
-        ))
+        }
+      }
+
+      it "returns correct OodCore::Job::Info object" do
+        is_expected.to eql(job_info)
       end
     end
 


### PR DESCRIPTION
This can be used in ActiveJobs and possibly iHPC Dashboard for gathering information on nodes/procs requested for jobs while they are in queue. It isn't guaranteed this information will be available though.