### PR TITLE
[WIP] LSF Adpater: info_where_owner optimization

### DIFF
--- a/lib/ood_core/job/adapters/lsf.rb
+++ b/lib/ood_core/job/adapters/lsf.rb
@@ -19,6 +19,8 @@ module OodCore
 
     module Adapters
       class Lsf < Adapter
+        using Refinements::ArrayExtensions
+
         # @api private
         attr_reader :batch, :helper
 
@@ -107,7 +109,14 @@ module OodCore
         # @return [Array<Info>] information describing submitted jobs
         # @see Adapter#info_where_owner
         def info_where_owner(owner)
-          batch.get_jobs_for_user(owner).map { |v| info_for_batch_hash(v) }
+          owners = Array.wrap(owner).map(&:to_s)
+          if owners.count > 1
+            super
+          elsif owners.count == 0
+            []
+          else
+	    batch.get_jobs_for_user(owners.first).map { |v| info_for_batch_hash(v) }
+	  end
         rescue Batch::Error => e
           raise JobAdapterError, e.message
         end

--- a/lib/ood_core/job/adapters/lsf.rb
+++ b/lib/ood_core/job/adapters/lsf.rb
@@ -102,6 +102,16 @@ module OodCore
           raise JobAdapterError, e.message
         end
 
+        # Retrieve info for all of the owner's jobs from the resource manager
+        # @raise [JobAdapterError] if something goes wrong getting job info
+        # @return [Array<Info>] information describing submitted jobs
+        # @see Adapter#info_where_owner
+        def info_where_owner(owner)
+          batch.get_jobs_for_user(owner).map { |v| info_for_batch_hash(v) }
+        rescue Batch::Error => e
+          raise JobAdapterError, e.message
+        end
+
         # Retrieve job status from resource manager
         # @param id [#to_s] the id of the job
         # @raise [JobAdapterError] if something goes wrong getting job status

--- a/lib/ood_core/job/adapters/lsf/batch.rb
+++ b/lib/ood_core/job/adapters/lsf/batch.rb
@@ -30,8 +30,11 @@ class OodCore::Job::Adapters::Lsf::Batch
   # @raise [Error] if `bjobs` command exited unsuccessfully
   # @return [Array<Hash>] list of details for jobs
   def get_jobs
-    #TODO: split into get_all_jobs, get_my_jobs
-    args = bjobs_default_args
+    get_jobs_for_user("all")
+  end
+
+  def get_jobs_for_user(user)
+    args = %W( -u #{user} -a -w -W )
     parse_bjobs_output(call("bjobs", *args))
   end
 
@@ -42,10 +45,6 @@ class OodCore::Job::Adapters::Lsf::Batch
   def get_job(id:)
     args = %W( -a -w -W #{id.to_s} )
     parse_bjobs_output(call("bjobs", *args)).first
-  end
-
-  def bjobs_default_args
-    %w( -u all -a -w -W )
   end
 
   # status fields available from bjobs

--- a/lib/ood_core/job/adapters/lsf/batch.rb
+++ b/lib/ood_core/job/adapters/lsf/batch.rb
@@ -55,9 +55,11 @@ class OodCore::Job::Adapters::Lsf::Batch
 
   # helper method
   def parse_bjobs_output(response)
-    return [] if response =~ /No .*job found/ || response.nil? || response.strip.empty?
+    return [] if response.nil? || response.strip.empty?
 
     lines = response.split("\n")
+    raise Error, "bjobs output in different format than expected: #{lines.inspect}" unless lines.count > 1
+
     columns = lines.shift.split
 
     validate_bjobs_output_columns(columns)

--- a/lib/ood_core/job/adapters/lsf/batch.rb
+++ b/lib/ood_core/job/adapters/lsf/batch.rb
@@ -57,7 +57,7 @@ class OodCore::Job::Adapters::Lsf::Batch
 
   # helper method
   def parse_bjobs_output(response)
-    return [] if response =~ /No job found/ || response.nil?
+    return [] if response =~ /No job found/ || response.nil? || response.strip.empty?
 
     lines = response.split("\n")
     columns = lines.shift.split

--- a/lib/ood_core/job/adapters/lsf/batch.rb
+++ b/lib/ood_core/job/adapters/lsf/batch.rb
@@ -40,8 +40,7 @@ class OodCore::Job::Adapters::Lsf::Batch
   # @raise [Error] if `bjobs` command exited unsuccessfully
   # @return [Hash] details of specified job
   def get_job(id:)
-    args = bjobs_default_args
-    args << id.to_s
+    args = %W( -a -w -W #{id.to_s} )
     parse_bjobs_output(call("bjobs", *args)).first
   end
 

--- a/lib/ood_core/job/adapters/lsf/batch.rb
+++ b/lib/ood_core/job/adapters/lsf/batch.rb
@@ -57,7 +57,7 @@ class OodCore::Job::Adapters::Lsf::Batch
 
   # helper method
   def parse_bjobs_output(response)
-    return [] if response =~ /No job found/ || response.nil? || response.strip.empty?
+    return [] if response =~ /No .*job found/ || response.nil? || response.strip.empty?
 
     lines = response.split("\n")
     columns = lines.shift.split

--- a/spec/job/adapters/lsf/batch_spec.rb
+++ b/spec/job/adapters/lsf/batch_spec.rb
@@ -155,13 +155,6 @@ JOBID      USER    STAT  QUEUE      FROM_HOST   EXEC_HOST   JOB_NAME   SUBMIT_TI
        }])
     end
 
-  describe "#get_jobs" do
-    it "calls bjobs with default args when id not specified" do
-      expect(batch).to receive(:call).with("bjobs", *batch.bjobs_default_args)
-      batch.get_jobs
-    end
-  end
-
   describe "#default_env" do
     subject(:batch) { described_class.new(config).default_env }
 

--- a/spec/job/adapters/lsf/batch_spec.rb
+++ b/spec/job/adapters/lsf/batch_spec.rb
@@ -24,6 +24,7 @@ describe OodCore::Job::Adapters::Lsf::Batch do
 
     it "handles no jobs in output" do
       expect(batch.parse_bjobs_output "No job found\n").to eq []
+      expect(batch.parse_bjobs_output "No unfinished job found\n").to eq []
     end
 
     it "raises exception for unexpected columns" do

--- a/spec/job/adapters/lsf/batch_spec.rb
+++ b/spec/job/adapters/lsf/batch_spec.rb
@@ -22,10 +22,12 @@ describe OodCore::Job::Adapters::Lsf::Batch do
       expect(batch.parse_bjobs_output "").to eq []
     end
 
-    it "handles no jobs in output" do
-      expect(batch.parse_bjobs_output "No job found\n").to eq []
-      expect(batch.parse_bjobs_output "No unfinished job found\n").to eq []
-    end
+    # this test is not valid because "No job found\n" etc. appear in
+    # stderr not stdout
+    # it "handles no jobs in output" do
+    #   expect(batch.parse_bjobs_output "No job found\n").to eq []
+    #   expect(batch.parse_bjobs_output "No unfinished job found\n").to eq []
+    # end
 
     it "raises exception for unexpected columns" do
       # I added ANOTHER_COLUMN to the end of this

--- a/spec/job/adapters/lsf/batch_spec.rb
+++ b/spec/job/adapters/lsf/batch_spec.rb
@@ -18,6 +18,10 @@ describe OodCore::Job::Adapters::Lsf::Batch do
       expect(batch.parse_bjobs_output nil).to eq []
     end
 
+    it "handles empty string" do
+      expect(batch.parse_bjobs_output "").to eq []
+    end
+
     it "handles no jobs in output" do
       expect(batch.parse_bjobs_output "No job found\n").to eq []
     end

--- a/spec/job/adapters/lsf_spec.rb
+++ b/spec/job/adapters/lsf_spec.rb
@@ -124,6 +124,29 @@ describe OodCore::Job::Adapters::Lsf do
         expect(adapter.info_all).to eq([expected_info])
       end
     end
+
+    describe "#info_where_owner" do
+      it "handles 0 owners" do
+        expect(adapter.info_where_owner([])).to eq([])
+        expect(adapter.info_where_owner(nil)).to eq([])
+      end
+
+      it "optimizes 1 owner" do
+        expect(batch).to receive(:get_jobs_for_user).with("efranz").and_return([])
+        adapter.info_where_owner("efranz")
+      end
+
+      it "optimizes 1 owner in array" do
+        expect(batch).to receive(:get_jobs_for_user).with("efranz").and_return([])
+        adapter.info_where_owner(["efranz"])
+      end
+
+      # we don't optimize multiple owners because LSF's bjobs doesn't accept -u with multiple users
+      it "doesn't optimize multiple owners" do
+        expect(batch).to receive(:get_jobs_for_user).exactly(0).times
+        expect(adapter.info_where_owner(["efranz", "jnicklas"])).to eq([expected_info])
+      end
+    end
   end
 
   describe ".build_lsf" do


### PR DESCRIPTION
Implement support for optimized info_where_owner in LSF adapter.

Unfortunately, it doesn't seem that, in at least LSF 8.3, bjobs can accept a list of users as arguments. Either one user or one group or all users.