### PR TITLE
add basic lsf multi-cluster support

### DIFF
--- a/lib/ood_core/job/adapters/lsf.rb
+++ b/lib/ood_core/job/adapters/lsf.rb
@@ -11,6 +11,7 @@ module OodCore
       # @option config [#to_s] :libdir ('') Path to lsf client lib dir
       # @option config [#to_s] :envdir ('') Path to lsf client conf dir
       # @option config [#to_s] :serverdir ('') Path to lsf client etc dir
+      # @option config [#to_s] :cluster ('') name of cluster, if in multi-cluster mode
       def self.build_lsf(config)
         batch = Adapters::Lsf::Batch.new(config.to_h.symbolize_keys)
         Adapters::Lsf.new(batch: batch)

--- a/spec/job/adapters/lsf/batch_spec.rb
+++ b/spec/job/adapters/lsf/batch_spec.rb
@@ -195,4 +195,31 @@ JOBID      USER    STAT  QUEUE      FROM_HOST   EXEC_HOST   JOB_NAME   SUBMIT_TI
       )}
     end
   end
+
+  describe "multinode" do
+    subject(:batch) { described_class.new(config).cluster_args }
+    context "when cluster not set" do
+      let(:config) {
+        {
+          bindir: "/opt/lsf/8.3/bin",
+          libdir: "/opt/lsf/8.3/lib",
+          envdir: "/opt/lsf/conf",
+          serverdir: "/opt/lsf/8.3/etc"
+        }
+      }
+      it { is_expected.to eq([]) }
+    end
+    context "when cluster not set" do
+      let(:config) {
+        {
+          bindir: "/opt/lsf/8.3/bin",
+          libdir: "/opt/lsf/8.3/lib",
+          envdir: "/opt/lsf/conf",
+          serverdir: "/opt/lsf/8.3/etc",
+          cluster: "curie"
+        }
+      }
+      it { is_expected.to eq(["-m", "curie"]) }
+    end
+  end
 end


### PR DESCRIPTION
in multi-cluster mode you must set the cluster when using
commands like bjobs and bsub etc. using -m "cluster"

so if cluster attribute is set in the job config, we assume
multi-cluster mode