### PR TITLE
VNC template should use random_number function.

### DIFF
--- a/lib/ood_core/batch_connect/templates/vnc.rb
+++ b/lib/ood_core/batch_connect/templates/vnc.rb
@@ -97,7 +97,7 @@ module OodCore
 
                 # Check that Xvnc process is running, if not assume it died and
                 # wait some random period of time before restarting
-                kill -0 ${VNC_PID} 2>/dev/null || sleep 0.$(random 1 9)s
+                kill -0 ${VNC_PID} 2>/dev/null || sleep 0.$(random_number 1 9)s
 
                 # If running, then all is well and break out of loop
                 kill -0 ${VNC_PID} 2>/dev/null && break


### PR DESCRIPTION
`lib/ood_core/batch_connect/templates/vnc.rb` currently tries to call `random 1 9` rather than `random_number 1 9`. The `random` command isn't defined and other places that need random numbers use `random_number`. For example:
```bash
# lib/ood_core/batch_connect/template.rb
local port=$(random_number "${2:-#{min_port}}" "${3:-#{max_port}}")
```

`random_number` is defined as a helper in `lib/ood_core/batch_connect/template.rb`:
```bash
random_number () {
  shuf -i ${1}-${2} -n 1
}
export -f random_number
```