### PR TITLE
Password context

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,11 +9,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Added
 - Added ability to override the default password length
 
-### Changed
-- Changed the default password length for VNC sessions to be 8
-
 ### Fixed
-- Fixed a bug in password creation where certain locales resulted in invalid passwords
+- Fixed a bug in password creation where certain locales resulted in invalid passwords [#91](https://github.com/OSC/ood_core/issues/91)
 
 ## [0.5.1] - 2018-05-14
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- Added ability to override the default password length
+
+### Changed
+- Changed the default password length for VNC sessions to be 8
+
+### Fixed
+- Fixed a bug in password creation where certain locales resulted in invalid passwords
 
 ## [0.5.1] - 2018-05-14
 ### Fixed

--- a/lib/ood_core/batch_connect/template.rb
+++ b/lib/ood_core/batch_connect/template.rb
@@ -8,6 +8,8 @@ module OodCore
       using Refinements::HashExtensions
       using Refinements::ArrayExtensions
 
+      DEFAULT_PASSWD_SIZE = 32
+
       # The context used to render this template
       # @return [Hash] context hash
       attr_reader :context
@@ -68,6 +70,10 @@ module OodCore
         EOT
       end
 
+      def passwd_size
+        context.fetch(:passwd_size, DEFAULT_PASSWD_SIZE).to_i
+      end
+
       private
         # Working directory that batch script runs in
         def work_dir
@@ -95,7 +101,7 @@ module OodCore
           context.fetch(:bash_helpers) do
             min_port    = context.fetch(:min_port, 2000).to_i
             max_port    = context.fetch(:max_port, 65535).to_i
-            passwd_size = context.fetch(:passwd_size, 32).to_i
+            # passwd_size = context.fetch(:passwd_size, 32).to_i
 
             <<-EOT.gsub(/^ {14}/, '')
               # Source in all the helper functions

--- a/lib/ood_core/batch_connect/template.rb
+++ b/lib/ood_core/batch_connect/template.rb
@@ -8,7 +8,7 @@ module OodCore
       using Refinements::HashExtensions
       using Refinements::ArrayExtensions
 
-      DEFAULT_PASSWD_SIZE = 32
+      DEFAULT_PASSWD_SIZE = 8
 
       # The context used to render this template
       # @return [Hash] context hash
@@ -149,7 +149,7 @@ module OodCore
 
                 # Generate random alphanumeric password with $1 (default: #{passwd_size}) characters
                 create_passwd () {
-                  tr -cd '[:alnum:]' < /dev/urandom 2> /dev/null | head -c${1:-#{passwd_size}}
+                  tr -cd 'a-zA-Z0-9' < /dev/urandom 2> /dev/null | head -c${1:-#{passwd_size}}
                 }
                 export -f create_passwd
               }

--- a/lib/ood_core/batch_connect/template.rb
+++ b/lib/ood_core/batch_connect/template.rb
@@ -8,8 +8,6 @@ module OodCore
       using Refinements::HashExtensions
       using Refinements::ArrayExtensions
 
-      DEFAULT_PASSWD_SIZE = 8
-
       # The context used to render this template
       # @return [Hash] context hash
       attr_reader :context
@@ -26,7 +24,7 @@ module OodCore
       #   for available port
       # @option context [#to_i] :max_port (65535) Maximum port used when
       #   looking for available port
-      # @option context [#to_i] :passwd_size (32) Length of randomly generated
+      # @option context [#to_i] :password_size (32) Length of randomly generated
       #   password
       # @option context [#to_s] :header ("") Shell code prepended at the top of
       #   the script body
@@ -70,9 +68,18 @@ module OodCore
         EOT
       end
 
-      def passwd_size
-        context.fetch(:passwd_size, DEFAULT_PASSWD_SIZE).to_i
-      end
+      protected
+        def password_size
+          context.fetch(:password_size, 8).to_i
+        end
+
+        def min_port
+          context.fetch(:min_port, 2000).to_i
+        end
+
+        def max_port
+          context.fetch(:max_port, 65535).to_i
+        end
 
       private
         # Working directory that batch script runs in
@@ -99,9 +106,7 @@ module OodCore
         # Helper methods used in the bash scripts
         def bash_helpers
           context.fetch(:bash_helpers) do
-            min_port    = context.fetch(:min_port, 2000).to_i
-            max_port    = context.fetch(:max_port, 65535).to_i
-            # passwd_size = context.fetch(:passwd_size, 32).to_i
+          
 
             <<-EOT.gsub(/^ {14}/, '')
               # Source in all the helper functions
@@ -147,9 +152,9 @@ module OodCore
                 }
                 export -f wait_until_port_used
 
-                # Generate random alphanumeric password with $1 (default: #{passwd_size}) characters
+                # Generate random alphanumeric password with $1 (default: #{password_size}) characters
                 create_passwd () {
-                  tr -cd 'a-zA-Z0-9' < /dev/urandom 2> /dev/null | head -c${1:-#{passwd_size}}
+                  tr -cd 'a-zA-Z0-9' < /dev/urandom 2> /dev/null | head -c${1:-#{password_size}}
                 }
                 export -f create_passwd
               }

--- a/lib/ood_core/batch_connect/templates/vnc.rb
+++ b/lib/ood_core/batch_connect/templates/vnc.rb
@@ -71,8 +71,8 @@ module OodCore
               # Setup one-time use passwords and initialize the VNC password
               function change_passwd () {
                 echo "Setting VNC password..."
-                password=$(create_passwd "#{passwd_size}")
-                spassword=${spassword:-$(create_passwd "#{passwd_size}")}
+                password=$(create_passwd "#{password_size}")
+                spassword=${spassword:-$(create_passwd "#{password_size}")}
                 (
                   umask 077
                   echo -ne "${password}\\n${spassword}" | vncpasswd -f > "#{vnc_passwd}"

--- a/lib/ood_core/batch_connect/templates/vnc.rb
+++ b/lib/ood_core/batch_connect/templates/vnc.rb
@@ -71,8 +71,8 @@ module OodCore
               # Setup one-time use passwords and initialize the VNC password
               function change_passwd () {
                 echo "Setting VNC password..."
-                password=$(create_passwd 8)
-                spassword=${spassword:-$(create_passwd 8)}
+                password=$(create_passwd "#{passwd_size}")
+                spassword=${spassword:-$(create_passwd "#{passwd_size}")}
                 (
                   umask 077
                   echo -ne "${password}\\n${spassword}" | vncpasswd -f > "#{vnc_passwd}"


### PR DESCRIPTION
This sets a default password length of 8 to maintain backwards compatibilty, while providing the ability to override the default in `submit.yml.erb` by setting the key `batch_connect.passwd_size` to a positive non-zero integer value.

```yaml
---
batch_connect:
  template: vnc
  passwd_size: 16  # <-- optional new stuff
script:
  native:
    resources:
      nodes: "<%= bc_num_slots %><%= node_type %>"
```

Also fixes a bug where some values for the `LANG` environment variable might result in invalid passwords by making the character ranges available to `tr` more explicit.

Addresses #93 and #91.