### PR TITLE
Fix issue with Slurm 18 squeue output format bug

### DIFF
--- a/lib/ood_core/job/adapters/slurm.rb
+++ b/lib/ood_core/job/adapters/slurm.rb
@@ -150,11 +150,11 @@ module OodCore
             end
 
             # Fields requested from a formatted `squeue` call
+            # Note that the order of these fields is important
             def fields
               {
                 account: "%a",
                 job_id: "%A",
-                gres: "%b",
                 exec_host: "%B",
                 min_cpus: "%c",
                 cpus: "%C",
@@ -200,7 +200,8 @@ module OodCore
                 nice: "%y",
                 scheduled_nodes: "%Y",
                 sockets_cores_threads: "%z",
-                work_dir: "%Z"
+                work_dir: "%Z",
+                gres: "%b",  # must come at the end to fix a bug with Slurm 18
               }
             end
         end

--- a/spec/job/adapters/slurm_spec.rb
+++ b/spec/job/adapters/slurm_spec.rb
@@ -851,4 +851,12 @@ describe OodCore::Job::Adapters::Slurm do
       end
     end
   end
+
+  describe "OodCore::Job::Adapters::Slurm::Batch" do
+    subject(:batch) { OodCore::Job::Adapters::Slurm::Batch.new }
+
+    it "has its fields in the correct order to work with Slurm 18" do
+      expect(batch.send(:fields).values.last).to eq("%b")
+    end
+  end
 end


### PR DESCRIPTION
Adds fix and test

Since Slurm 18 `squeue` stopped outputting delimiters after `%b`. We are reliant on delimiters, we can work around this issue by moving `%b` to the end of the field list, and rely on Ruby's ordered hashes to leave the entry at the end.

Fixes #99, and is a better solution than #105.