### PR TITLE
Add Adapter#supports_job_arrays?

### DIFF
--- a/lib/ood_core/job/adapter.rb
+++ b/lib/ood_core/job/adapter.rb
@@ -105,6 +105,13 @@ module OodCore
         end
       end
 
+      # Whether the adapter supports job arrays
+      # @return [Boolean] - assumes true; but can be overridden by adapters that
+      #   explicitly do not
+      def supports_job_arrays?
+        true
+      end
+
       # Retrieve job info from the resource manager
       # @abstract Subclass is expected to implement {#info}
       # @raise [NotImplementedError] if subclass did not define {#info}

--- a/lib/ood_core/job/adapters/lsf.rb
+++ b/lib/ood_core/job/adapters/lsf.rb
@@ -131,6 +131,10 @@ module OodCore
           raise JobAdapterError, e.message
         end
 
+        def supports_job_arrays?
+          false
+        end
+
         # Retrieve job status from resource manager
         # @param id [#to_s] the id of the job
         # @raise [JobAdapterError] if something goes wrong getting job status

--- a/lib/ood_core/job/adapters/pbspro.rb
+++ b/lib/ood_core/job/adapters/pbspro.rb
@@ -307,6 +307,10 @@ module OodCore
         end
       end
 
+        def supports_job_arrays?
+          false
+        end
+
         # Retrieve job info from the resource manager
         # @param id [#to_s] the id of the job
         # @raise [JobAdapterError] if something goes wrong getting job info

--- a/spec/job/adapters/lsf_spec.rb
+++ b/spec/job/adapters/lsf_spec.rb
@@ -15,6 +15,10 @@ describe OodCore::Job::Adapters::Lsf do
   it { is_expected.to respond_to(:release).with(1).argument }
   it { is_expected.to respond_to(:delete).with(1).argument }
 
+  it "claims to NOT support job arrays" do
+    expect(subject.supports_job_arrays?).to be_falsey
+  end
+
   describe "#submit" do
     def build_script(opts = {})
       OodCore::Job::Script.new(

--- a/spec/job/adapters/pbspro_spec.rb
+++ b/spec/job/adapters/pbspro_spec.rb
@@ -18,6 +18,10 @@ describe OodCore::Job::Adapters::PBSPro do
   it { is_expected.to respond_to(:release).with(1).argument }
   it { is_expected.to respond_to(:delete).with(1).argument }
 
+  it "claims to NOT support job arrays" do
+    expect(subject.supports_job_arrays?).to be_falsey
+  end
+
   describe ".new" do
     context "when :pbspro not defined" do
       subject { described_class.new }

--- a/spec/job/adapters/sge_spec.rb
+++ b/spec/job/adapters/sge_spec.rb
@@ -15,6 +15,11 @@ describe OodCore::Job::Adapters::Sge do
   it { is_expected.to respond_to(:release).with(1).argument }
   it { is_expected.to respond_to(:delete).with(1).argument }
 
+  it "claims to support job arrays" do
+    expect(subject.supports_job_arrays?).to be_truthy
+  end
+
+
 describe "#submit" do
     def build_script(opts = {})
       OodCore::Job::Script.new(

--- a/spec/job/adapters/slurm_spec.rb
+++ b/spec/job/adapters/slurm_spec.rb
@@ -16,6 +16,10 @@ describe OodCore::Job::Adapters::Slurm do
   it { is_expected.to respond_to(:release).with(1).argument }
   it { is_expected.to respond_to(:delete).with(1).argument }
 
+  it "claims to support job arrays" do
+    expect(subject.supports_job_arrays?).to be_truthy
+  end
+
   describe ".new" do
     context "when :slurm not defined" do
       subject { described_class.new }

--- a/spec/job/adapters/torque_spec.rb
+++ b/spec/job/adapters/torque_spec.rb
@@ -17,6 +17,10 @@ describe OodCore::Job::Adapters::Torque do
   it { is_expected.to respond_to(:release).with(1).argument }
   it { is_expected.to respond_to(:delete).with(1).argument }
 
+  it "claims to support job arrays" do
+    expect(subject.supports_job_arrays?).to be_truthy
+  end
+
   describe ".new" do
     context "when :pbs not defined" do
       subject { described_class.new }


### PR DESCRIPTION
Add boolean indicating whether or not a job adapter supports job arrays.

We might consider a general purpose version of a method like this, for all "features", such as all the submit options on Script and all of the Info attrs.