### PR TITLE
SGE defaults to passing the -cwd flag

### DIFF
--- a/lib/ood_core/job/adapters/sge.rb
+++ b/lib/ood_core/job/adapters/sge.rb
@@ -83,7 +83,7 @@ module OodCore
           # SGE supports jod dependencies on job completion
           args = @helper.batch_submit_args(script, after: after, afterok: afterok, afternotok: afternotok, afterany: afterany)
 
-          @batch.submit(script.content, args, :chdir => script.workdir)
+          @batch.submit(script.content, args)
         rescue Batch::Error => e
           raise JobAdapterError, e.message
         end

--- a/lib/ood_core/job/adapters/sge/helper.rb
+++ b/lib/ood_core/job/adapters/sge/helper.rb
@@ -20,7 +20,12 @@ class OodCore::Job::Adapters::Sge::Helper
     args += ['-h'] if script.submit_as_hold
     args += ['-r', 'yes'] if script.rerunnable
     script.job_environment.each_pair {|k, v| args += ['-v', "#{k.to_s}=#{v.to_s}"]} unless script.job_environment.nil?
-    args += ['-wd', script.workdir] unless script.workdir.nil?
+
+    if script.workdir
+      args += ['-wd', script.workdir]
+    elsif ! script_contains_wd_directive?(script.content)
+      args += ['-cwd']
+    end
 
     on_event_email = []
     on_event_email << 'b' if script.email_on_started  # beginning
@@ -45,6 +50,41 @@ class OodCore::Job::Adapters::Sge::Helper
     args += Array.wrap(script.native) if script.native
 
     args
+  end
+
+  # @brief      Detect whether script content contains either -cwd or -wd
+  #
+  # @param      content  The script content
+  # 
+  # Examples:
+  #     #$-wd /home/ood/ondemand  # should match
+  #     #$  -wd /home/ood/ondemand  # should match
+  #     #$  -cwd /home/ood/ondemand  # should match
+  #     #$ -j yes -wd /home/ood/ondemand  # should match
+  #     #$ -j yes -o this-wd /home/ood/ondemand  # should NOT match
+  #       #$ -t 1-10:5 -wd /home/ood/ondemand  # should NOT match
+  #
+  # @return     [bool]
+  #
+  def script_contains_wd_directive?(content)
+    content.slice(
+      # Only search within the script's first 1024 characters in case the user is
+      # putting non-line delimited data into their scripts.
+      0, 1024
+    ).split(
+      "\n"
+    ).slice(
+      # Only scan in the first 20 rows
+      0, 20
+    ).any? {
+      |line|
+      # String must start with #$
+      # Match may be:
+      #   Immediate -c?wd
+      #   Eventual space or tab followed by -c?wd
+      # String may end with multiple characters
+      /^#\$(?:-c?wd|.*[ \t]+-c?wd).*$/ =~ line
+    }
   end
 
   # Raise exceptions when adapter is asked to perform an action that SGE does not support

--- a/lib/ood_core/job/adapters/sge/helper.rb
+++ b/lib/ood_core/job/adapters/sge/helper.rb
@@ -69,13 +69,10 @@ class OodCore::Job::Adapters::Sge::Helper
   def script_contains_wd_directive?(content)
     content.slice(
       # Only search within the script's first 1024 characters in case the user is
-      # putting non-line delimited data into their scripts.
+      # putting lots of non-line delimited data into their scripts.
       0, 1024
     ).split(
       "\n"
-    ).slice(
-      # Only scan in the first 20 rows
-      0, 20
     ).any? {
       |line|
       # String must start with #$

--- a/spec/job/adapters/sge/helper_spec.rb
+++ b/spec/job/adapters/sge/helper_spec.rb
@@ -10,7 +10,7 @@ describe OodCore::Job::Adapters::Sge::Helper do
     let(:match_cwd) {'#$  -cwd /home/ood/ondemand'}
     let(:match_multiple_directives) {'#$  -wd /home/ood/ondemand'}
 
-    let(:should_not_match_embedded_wd) {' #$ -j yes -o this-wd /home/ood/ondemand'}
+    let(:should_not_match_embedded_wd) {'#$ -j yes -o this-wd /home/ood/ondemand'}
     let(:should_not_match_bad_indent) {'  #$ -t 1-10:5 -wd /home/ood/ondemand'}
 
     it "detects c?wd directives in a script" do

--- a/spec/job/adapters/sge/helper_spec.rb
+++ b/spec/job/adapters/sge/helper_spec.rb
@@ -1,0 +1,26 @@
+require "spec_helper"
+require "ood_core/job/adapters/sge/helper"
+
+describe OodCore::Job::Adapters::Sge::Helper do
+  subject(:helper) {described_class.new}
+
+  describe "#script_contains_wd_directive?" do
+    let(:match_w_no_space) {'#$-wd /home/ood/ondemand'}
+    let(:match_leading_space) {'#$  -wd /home/ood/ondemand'}
+    let(:match_cwd) {'#$  -cwd /home/ood/ondemand'}
+    let(:match_multiple_directives) {'#$  -wd /home/ood/ondemand'}
+
+    let(:should_not_match_embedded_wd) {' #$ -j yes -o this-wd /home/ood/ondemand'}
+    let(:should_not_match_bad_indent) {'  #$ -t 1-10:5 -wd /home/ood/ondemand'}
+
+    it "detects c?wd directives in a script" do
+        expect(helper.script_contains_wd_directive?(match_w_no_space)).to be_truthy
+        expect(helper.script_contains_wd_directive?(match_leading_space)).to be_truthy
+        expect(helper.script_contains_wd_directive?(match_cwd)).to be_truthy
+        expect(helper.script_contains_wd_directive?(match_multiple_directives)).to be_truthy
+
+        expect(helper.script_contains_wd_directive?(should_not_match_embedded_wd)).to be_falsey
+        expect(helper.script_contains_wd_directive?(should_not_match_bad_indent)).to be_falsey
+    end
+  end
+end

--- a/spec/job/adapters/sge_spec.rb
+++ b/spec/job/adapters/sge_spec.rb
@@ -42,26 +42,26 @@ describe "#submit" do
 
     it "returns job id" do
       is_expected.to eq("123")
-      expect(batch).to have_received(:submit).with(content, [])
+      expect(batch).to have_received(:submit).with(content, ["-cwd"])
     end
 
     context "with :queue_name" do
       before { adapter.submit(build_script(queue_name: "queue")) }
 
-      it { expect(batch).to have_received(:submit).with(content, ["-q", "queue"]) }
+      it { expect(batch).to have_received(:submit).with(content, ["-cwd", "-q", "queue"]) }
     end
 
     context "with :submit_as_hold" do
       context "as true" do
         before { adapter.submit(build_script(submit_as_hold: true)) }
 
-        it { expect(batch).to have_received(:submit).with(content, ["-h"]) }
+        it { expect(batch).to have_received(:submit).with(content, ["-h", "-cwd"]) }
       end
 
       context "as false" do
         before { adapter.submit(build_script(submit_as_hold: false)) }
 
-        it { expect(batch).to have_received(:submit).with(content, []) }
+        it { expect(batch).to have_received(:submit).with(content, ["-cwd"]) }
       end
     end
 
@@ -69,20 +69,20 @@ describe "#submit" do
       context "as true" do
         before { adapter.submit(build_script(rerunnable: true)) }
 
-        it { expect(batch).to have_received(:submit).with(content, ["-r", "yes"]) }
+        it { expect(batch).to have_received(:submit).with(content, ["-r", "yes", "-cwd"]) }
       end
 
       context "as false" do
         before { adapter.submit(build_script(rerunnable: false)) }
 
-        it { expect(batch).to have_received(:submit).with(content, []) }
+        it { expect(batch).to have_received(:submit).with(content, ["-cwd"]) }
       end
     end
 
     context "with :job_environment" do
       before { adapter.submit(build_script(job_environment: {"key" => "value"})) }
 
-      it { expect(batch).to have_received(:submit).with(content, ["-v", "key=value"]) }
+      it { expect(batch).to have_received(:submit).with(content, ["-v", "key=value", "-cwd"]) }
     end
 
     context "with :workdir" do
@@ -95,13 +95,13 @@ describe "#submit" do
       context "as true" do
         before { adapter.submit(build_script(email: ["email1", "email2"], email_on_started: true)) }
 
-        it { expect(batch).to have_received(:submit).with(content, ["-M", "email1", "-m", "b"]) }
+        it { expect(batch).to have_received(:submit).with(content, ["-cwd", "-M", "email1", "-m", "b"]) }
       end
 
       context "as false" do
         before { adapter.submit(build_script(email_on_started: false)) }
 
-        it { expect(batch).to have_received(:submit).with(content, []) }
+        it { expect(batch).to have_received(:submit).with(content, ["-cwd"]) }
       end
     end
 
@@ -109,86 +109,86 @@ describe "#submit" do
       context "as true" do
         before { adapter.submit(build_script(email: ["email1", "email2"], email_on_terminated: true)) }
 
-        it { expect(batch).to have_received(:submit).with(content, ["-M", "email1", "-m", "ea"]) }
+        it { expect(batch).to have_received(:submit).with(content, ["-cwd", "-M", "email1", "-m", "ea"]) }
       end
 
       context "as false" do
         before { adapter.submit(build_script(email_on_terminated: false)) }
 
-        it { expect(batch).to have_received(:submit).with(content, []) }
+        it { expect(batch).to have_received(:submit).with(content, ["-cwd"]) }
       end
     end
 
     context "with :email_on_started and :email_on_terminated" do
       before { adapter.submit(build_script(email: ["email1", "email2"], email_on_started: true, email_on_terminated: true)) }
 
-      it { expect(batch).to have_received(:submit).with(content, ["-M", "email1", "-m", "bea"]) }
+      it { expect(batch).to have_received(:submit).with(content, ["-cwd", "-M", "email1", "-m", "bea"]) }
     end
 
     context "with :job_name" do
       before { adapter.submit(build_script(job_name: "my_job")) }
 
-      it { expect(batch).to have_received(:submit).with(content, ["-N", "my_job"]) }
+      it { expect(batch).to have_received(:submit).with(content, ["-cwd", "-N", "my_job"]) }
     end
 
     context "with :output_path" do
       before { adapter.submit(build_script(output_path: "/path/to/output")) }
 
-      it { expect(batch).to have_received(:submit).with(content, ["-o", Pathname.new("/path/to/output")]) }
+      it { expect(batch).to have_received(:submit).with(content, ["-cwd", "-o", Pathname.new("/path/to/output")]) }
     end
 
     context "with :error_path" do
       before { adapter.submit(build_script(error_path: "/path/to/error")) }
 
-      it { expect(batch).to have_received(:submit).with(content, ["-e", Pathname.new("/path/to/error")]) }
+      it { expect(batch).to have_received(:submit).with(content, ["-cwd", "-e", Pathname.new("/path/to/error")]) }
     end
 
     context "with :reservation_id" do
       before { adapter.submit(build_script(reservation_id: "my_rsv")) }
 
-      it { expect(batch).to have_received(:submit).with(content, ["-ar", "my_rsv"]) }
+      it { expect(batch).to have_received(:submit).with(content, ["-cwd", "-ar", "my_rsv"]) }
     end
 
     context "with :priority" do
       before { adapter.submit(build_script(priority: 123)) }
 
-      it { expect(batch).to have_received(:submit).with(content, ["-p", 123]) }
+      it { expect(batch).to have_received(:submit).with(content, ["-cwd", "-p", 123]) }
     end
 
     context "with :start_time" do
       before { adapter.submit(build_script(start_time: Time.new(2016, 11, 8, 13, 53, 54).to_i)) }
 
-      it { expect(batch).to have_received(:submit).with(content, ["-a", "201611081353.54"]) }
+      it { expect(batch).to have_received(:submit).with(content, ["-cwd", "-a", "201611081353.54"]) }
     end
 
     context "with :accounting_id" do
       before { adapter.submit(build_script(accounting_id: "my_account")) }
 
-      it { expect(batch).to have_received(:submit).with(content, ["-P", "my_account"]) }
+      it { expect(batch).to have_received(:submit).with(content, ["-cwd", "-P", "my_account"]) }
     end
 
     context "with :wall_time" do
       before { adapter.submit(build_script(wall_time: 94534)) }
 
-      it { expect(batch).to have_received(:submit).with(content, ["-l", "h_rt=26:15:34"]) }
+      it { expect(batch).to have_received(:submit).with(content, ["-cwd", "-l", "h_rt=26:15:34"]) }
     end
 
     context "with :native" do
       before { adapter.submit(build_script(native: ["A", "B", "C"])) }
 
-      it { expect(batch).to have_received(:submit).with(content, ["A", "B", "C"]) }
+      it { expect(batch).to have_received(:submit).with(content, ["-cwd", "A", "B", "C"]) }
     end
 
     context "and :afterok is defined as a single job id" do
       before { adapter.submit(build_script, afterok: "job_id") }
 
-      it { expect(batch).to have_received(:submit).with(content, ["-hold_jid_ad", "job_id"]) }
+      it { expect(batch).to have_received(:submit).with(content, ["-cwd", "-hold_jid_ad", "job_id"]) }
     end
 
     context "and :afterok is defined as multiple job ids" do
       before { adapter.submit(build_script, afterok: ["job1", "job2"]) }
 
-      it { expect(batch).to have_received(:submit).with(content, ["-hold_jid_ad", "job1,job2"]) }
+      it { expect(batch).to have_received(:submit).with(content, ["-cwd", "-hold_jid_ad", "job1,job2"]) }
     end
 
     context "and when features that SGE does not support are used" do


### PR DESCRIPTION
By setting `-cwd` we ensure that stdout/stderr are written to the correct place. With GE a script's content does not override command line options to `qsub`. The GE helper attempts to work around the `qsub` limitations by detecting `-wd` and `-cwd` directives in the first 1024 characters and first 20 lines of a script, thus allowing us to be selective about whether we want to force the `-cwd` flag to be set or not.

Tests were written for the helper method. Note as well that `-cwd` became a default option for the `#submit` tests, necessitating its inclusion.