### PR TITLE
Replace job array spec parser with Parslet::Parser

### DIFF
--- a/lib/ood_core/job/array_ids.rb
+++ b/lib/ood_core/job/array_ids.rb
@@ -17,7 +17,6 @@ module OodCore
 
       class ArraySpecParser < Parslet::Parser
         rule(:integer) { match('[0-9]').repeat(1) }
-        # rule(:integer_gt_zero) { match('[1-9][0-9]*') }
         rule(:max_concurrent) { str('%') >> integer }
         rule(:range) { integer.as(:start) >> str('-') >> integer.as(:stop) }
         rule(:stepped_range) { range >> str(':') >> integer.as(:step) }
@@ -47,7 +46,7 @@ module OodCore
         Array.wrap(ArraySpecParser.new.parse(@spec_string)).map do |component|
           ArraySpecComponent.new(**component).to_a
         end.reduce(:+).sort
-      rescue
+      rescue ArgumentError, Parslet::ParseFailed
         []
       end
     end

--- a/ood_core.gemspec
+++ b/ood_core.gemspec
@@ -24,6 +24,7 @@ Gem::Specification.new do |spec|
 
   spec.add_runtime_dependency "ood_support", "~> 0.0.2"
   spec.add_runtime_dependency "ffi", "~> 1.9", ">= 1.9.6"
+  spec.add_runtime_dependency "parslet", "~> 1.8"
   spec.add_development_dependency "bundler", "~> 1.7"
   spec.add_development_dependency "rake", "~> 10.0"
   spec.add_development_dependency "rspec", "~> 3.0"

--- a/spec/job/array_ids_spec.rb
+++ b/spec/job/array_ids_spec.rb
@@ -47,11 +47,11 @@ describe OodCore::Job::ArrayIds do
         described_class.new('1,3-6:3,7,9-11,13,15-17,20-30:2').ids
       ).to eql([1, 3, 6, 7, 9, 10, 11, 13, 15, 16, 17, 20, 22, 24, 26, 28, 30])
     end
+  end
 
-    it "returns the correct IDs" do
-      expect( 
-        described_class.new('1,3-6:3,7,9-11,13,15-17,20-30:2%5').ids
-      ).to eql([1, 3, 6, 7, 9, 10, 11, 13, 15, 16, 17, 20, 22, 24, 26, 28, 30])
+  context "when the spec contains a percent modifier, but no number" do
+    it "returns an empty array" do
+      expect( described_class.new('1-4%').ids ).to eql([])
     end
   end
 
@@ -82,12 +82,6 @@ describe OodCore::Job::ArrayIds do
   context "when the spec is garbage" do
     it "returns an empty array" do
       expect(described_class.new('1!@-#$%^&*()DHKI%^&*(@)#@_!-=').ids).to eq([])
-    end
-  end
-
-  context "when the spec is invalid and ends with a comma" do
-    it "returns an empty array" do
-      expect(described_class.new('1-4%2,').ids).to eq([])
     end
   end
 end

--- a/spec/job/array_ids_spec.rb
+++ b/spec/job/array_ids_spec.rb
@@ -47,6 +47,12 @@ describe OodCore::Job::ArrayIds do
         described_class.new('1,3-6:3,7,9-11,13,15-17,20-30:2').ids
       ).to eql([1, 3, 6, 7, 9, 10, 11, 13, 15, 16, 17, 20, 22, 24, 26, 28, 30])
     end
+
+    it "returns the correct IDs" do
+      expect( 
+        described_class.new('1,3-6:3,7,9-11,13,15-17,20-30:2%5').ids
+      ).to eql([1, 3, 6, 7, 9, 10, 11, 13, 15, 16, 17, 20, 22, 24, 26, 28, 30])
+    end
   end
 
   context "when the spec is nil" do
@@ -76,6 +82,12 @@ describe OodCore::Job::ArrayIds do
   context "when the spec is garbage" do
     it "returns an empty array" do
       expect(described_class.new('1!@-#$%^&*()DHKI%^&*(@)#@_!-=').ids).to eq([])
+    end
+  end
+
+  context "when the spec is invalid and ends with a comma" do
+    it "returns an empty array" do
+      expect(described_class.new('1-4%2,').ids).to eq([])
     end
   end
 end


### PR DESCRIPTION
The current implementation of the job spec array parser is valid enough for production use although not perfect ([it fails this test](https://github.com/OSC/ood_core/blob/try-parslet/spec/job/array_ids_spec.rb#L88-L92)). @ericfranz suggested replacing the current implementation with something based on regular expressions, which is doable but not very readable.

An alternative to both the current implementation and a regex based approach is to use a [parsing expression grammar](https://en.wikipedia.org/wiki/Parsing_expression_grammar) framework like [Parselet](http://kschiess.github.io/parslet/). Using Parslet allows us to redefine the parsing and validating section of our code like so:

```ruby
class ArraySpecParser < Parslet::Parser
    rule(:integer) { match('[0-9]').repeat(1) }
    rule(:max_concurrent) { str('%') >> integer }
    rule(:range) { integer.as(:start) >> str('-') >> integer.as(:stop) }
    rule(:stepped_range) { range >> str(':') >> integer.as(:step) }
    rule(:component) { stepped_range | range | integer.as(:start) }
    rule(:additional_component) { str(',') >> component }
    rule(:array_spec) { component >> additional_component.repeat >> max_concurrent.maybe }
    root(:array_spec)
end

ArraySpecParser.new.parse('1-10:2%5')
# {:start => "1", :stop => "10", :step => "5"}
ArraySpecParser.new.parse('1-4,2')
# [{:start => "1", :stop => "10"}, {:start => "1"}]
ArraySpecParser.new.parse(nil)
# ArgumentError
ArraySpecParser.new.parse('this wont parse')
# Parslet::ParseFailed
```

There is a performance penalty to switching to Parslet with the Parslet implementation taking on average an additional 0.0027 seconds per run of the 13 out of 14 tests that master passes (each `bundle exec rspec spec/job/array_ids_spec.rb` was run 10 times). I am not convinced that this penalty is a deal breaker for us. I have not compared the Parslet implementation against one that is regex-based. Of course there is also the addition of a new dependency to consider. In general I think that we should prefer using something like Parslet over complex regular expressions when writing parsers unless we have a compelling reason to given the increase in clarity.

Fixes #144.