### PR TITLE
Add cluster ACLs based on the cluster config's file permissions

### DIFF
--- a/lib/ood_core/clusters.rb
+++ b/lib/ood_core/clusters.rb
@@ -18,10 +18,12 @@ module OodCore
         config = Pathname.new(path.to_s).expand_path
 
         clusters = []
-        if config.file? && config.readable?
-          CONFIG_VERSION.any? do |version|
-            YAML.safe_load(config.read).fetch(version, {}).each do |k, v|
-              clusters << Cluster.new(send("parse_#{version}", id: k, cluster: v))
+        if config.file?
+          if config.readable?
+            CONFIG_VERSION.any? do |version|
+              YAML.safe_load(config.read).fetch(version, {}).each do |k, v|
+                clusters << Cluster.new(send("parse_#{version}", id: k, cluster: v))
+              end
             end
           end
         elsif config.directory?
@@ -32,7 +34,7 @@ module OodCore
               end
             end
           end
-        elsif ! config.exist?
+        else
           raise ConfigurationNotFound, "configuration file '#{config}' does not exist"
         end
 

--- a/lib/ood_core/clusters.rb
+++ b/lib/ood_core/clusters.rb
@@ -27,10 +27,10 @@ module OodCore
               !clusters.empty?
             end
           rescue Errno::EACCES
-	    false
+            false
           end
         elsif config.directory?
-	  begin
+          begin
             Pathname.glob(config.join("*.yml")).each do |p|
               CONFIG_VERSION.any? do |version|
                 if cluster = YAML.safe_load(p.read).fetch(version, nil)
@@ -41,8 +41,8 @@ module OodCore
                 end
               end
             end
-	  rescue Errno::EACCES
-	    false
+          rescue Errno::EACCES
+	          false
           end
         else
           raise ConfigurationNotFound, "configuration file '#{config}' does not exist"

--- a/spec/clusters_spec.rb
+++ b/spec/clusters_spec.rb
@@ -52,5 +52,13 @@ describe OodCore::Clusters do
         OodCore::Clusters.load_file(config)
       end
     end
+
+    context "when cluster config does not exist" do
+      let(:config) { Pathname.pwd + 'spec/fixtures/config/doesnotexist'}
+
+      it "raises OodCore::ConfigurationNotFound" do
+        expect { OodCore::Clusters.load_file(config) }.to raise_error(OodCore::ConfigurationNotFound)
+      end
+    end
   end
 end

--- a/spec/clusters_spec.rb
+++ b/spec/clusters_spec.rb
@@ -1,0 +1,56 @@
+require "spec_helper"
+require "pathname"
+
+describe OodCore::Clusters do
+  describe "#load_file" do
+    context "when loading a valid file" do
+      let(:config) { Pathname.pwd + 'spec/fixtures/config/clusters.d/oakley.yml'}
+
+      it "returns an array of OodCore::Cluster" do
+        clusters = OodCore::Clusters.load_file(config)
+        clusters.each do |cluster|
+          expect(cluster).to be_an_instance_of(OodCore::Cluster)
+        end
+      end
+    end
+
+    context "when loading directory of valid cluster config" do
+      let(:config) { Pathname.pwd + 'spec/fixtures/config/clusters.d'}
+
+      it "returns an array of OodCore::Cluster" do
+        clusters = OodCore::Clusters.load_file(config)
+        clusters.each do |cluster|
+          expect(cluster).to be_an_instance_of(OodCore::Cluster)
+        end
+      end
+    end
+
+    context "when loading an un-readable file" do
+      # Use real file so we do not have to mock all of Pathname
+      let(:config) { Pathname.pwd + 'spec/fixtures/config/clusters.d/oakley.yml'}
+
+      it "does not raise an error" do
+        # Mock file permission ACL
+        allow_any_instance_of(Pathname).to receive(:readable?).and_return(false)
+        # Throw error if logic is wrong
+        allow_any_instance_of(Pathname).to receive(:read).and_raise(Errno::EACCES)
+
+        OodCore::Clusters.load_file(config)
+      end
+    end
+
+    context "when loading a directory with un-readable files" do
+      # Use real file so we do not have to mock all of Pathname
+      let(:config) { Pathname.pwd + 'spec/fixtures/config/clusters.d'}
+
+      it "does not raise an error" do
+        # Mock file permission ACL
+        allow_any_instance_of(Pathname).to receive(:readable?).and_return(false)
+        # Throw error if logic is wrong
+        allow_any_instance_of(Pathname).to receive(:read).and_raise(Errno::EACCES)
+
+        OodCore::Clusters.load_file(config)
+      end
+    end
+  end
+end


### PR DESCRIPTION
Fixes crash when a YAML file in the clusters.d is not readable by the user