### PR TITLE
Adds a configuration class for use by all Ruby-based apps

### DIFF
--- a/lib/ood_core.rb
+++ b/lib/ood_core.rb
@@ -2,6 +2,7 @@ require "ood_core/version"
 require "ood_core/errors"
 require "ood_core/cluster"
 require "ood_core/clusters"
+require "ood_core/app_config"
 
 # The main namespace for ood_core
 module OodCore

--- a/lib/ood_core/app_config.rb
+++ b/lib/ood_core/app_config.rb
@@ -1,0 +1,168 @@
+require "ood_core/refinements/array_extensions"
+require 'pathname'
+require 'yaml'
+
+module OodCore
+    class AppConfig
+        using Refinements::ArrayExtensions
+
+        attr_reader :raw_config
+
+        def initialize
+        end
+
+        def load_config
+            @raw_config = YAML.load(load_yaml) || {}
+        end
+
+        def branding_bg_color
+            raw_config.dig('branding', 'bg_color') || '#53565a'
+        end
+
+        def branding_link_active_bg_color
+            raw_config.dig('branding', 'link_active_bg_color') || '#3b3d3f'
+        end
+
+        def branding_navbar_type
+            raw_config['navbar_type'] || 'inverse'
+        end
+
+        def branding_dashboard_header_logo
+            pathname_or_nil(raw_config.dig('branding', 'dashboard_header_logo'))
+        end
+
+        def branding_dashboard_logo
+            pathname_or_nil(raw_config.dig('branding', 'dashboard_logo'))
+        end
+
+        def branding_dashboard_title
+            raw_config.dig('branding', 'dashboard_title') || 'Open OnDemand'
+        end
+
+        def default_ssh_host
+            raw_config['default_ssh_host']
+        end
+
+        def disable_safari_basic_auth_warning
+            setting = raw_config['disable_safari_basic_auth_warning']
+            return true if setting.nil?
+
+            !! setting
+        end
+        alias_method :disable_safari_basic_auth_warning?, :disable_safari_basic_auth_warning
+
+        def enable_native_vnc
+            !! raw_config['enable_native_vnc']
+        end
+        alias_method :enable_native_vnc?, :enable_native_vnc
+
+        def file_upload_max
+            (raw_config['file_upload_max'] || 10485760000).to_i
+        end
+
+        def motd_format
+            raw_config.dig('motd', 'format')
+        end
+
+        def motd_uri
+            raw_config.dig('motd', 'uri')
+        end
+
+        def announcement_path
+            Array.wrap(raw_config['announcement_path'] || []).map do |path|
+                Pathname.new(path)
+            end
+        end
+
+        def app_catalog_url
+            raw_config['app_catalog_url']
+        end
+
+        # Replaces: app_development
+        def show_app_development
+            !! raw_config['app_development']
+        end
+        alias_method :show_app_development?, :show_app_development
+
+        def app_sharing
+            !! raw_config['app_sharing']
+        end
+        alias_method :app_sharing?, :app_sharing
+
+        def dev_ssh_host
+            raw_config['dev_ssh_host']
+        end
+
+        def user_file_system_locations
+            Array.wrap(raw_config['user_file_system_locations'] || []).map do |location|
+                Pathname.new(location)
+            end
+        end
+
+        def links
+            raw_config['links'] || {}
+        end
+
+        def load_external_bc_config
+            setting = raw_config['load_external_bc_config']
+            return true if setting.nil?
+
+            !! setting
+        end
+        alias_method :load_external_bc_config?, :load_external_bc_config
+
+        def load_external_config
+            setting = raw_config['load_external_config']
+            return true if setting.nil?
+
+            !! setting
+        end
+        alias_method :load_external_config?, :load_external_config
+
+        def locale
+            raw_config['locale'] || 'en'
+        end
+
+        def locales_root
+            Pathname.new(raw_config['locales_root'] || '/etc/ood/config/locales')
+        end
+
+        def quota_path
+            Array.wrap(raw_config['quota_path'] || []).map do |path|
+                Pathname.new(path)
+            end
+        end
+
+        def ssh_hosts
+            raw_config['ssh_hosts'] || []
+        end
+
+        def poll_delay
+            (raw_config['poll_delay'] || 10000).to_i
+        end
+
+        def show_all_apps_link
+            !! raw_config['show_all_apps_link']
+        end
+        alias_method :show_all_apps_link?, :show_all_apps_link
+
+        def whitelist_path
+            raw_config['whitelist_path'] || []
+        end
+
+        class Error < StandardError; end
+
+        private
+
+        def load_yaml
+            erb_wrapper_path = Pathname.new(ENV['OOD_CONFIG_ERB_WRAPPER'] || '/etc/ood/config/bin/erb_wrapper')
+            app_config_path = Pathname.new(ENV['OOD_APP_CONFIG'] || '/etc/ood/config/app_config.yml')
+            o, e, s = Open3.capture3(erb_wrapper_path.to_s, app_config_path.to_s)
+            s.success? ? o : raise(Error, e)
+        end
+
+        def pathname_or_nil(path)
+            (path) ? Pathname.new(path) : nil
+        end
+    end
+end

--- a/ood_core.gemspec
+++ b/ood_core.gemspec
@@ -29,4 +29,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "rspec", "~> 3.0"
   spec.add_development_dependency "pry", "~> 0.10"
   spec.add_development_dependency "timecop", "~> 0.8"
+  spec.add_development_dependency "climate_control", "~> 0.2.0"
 end

--- a/spec/app_config_spec.rb
+++ b/spec/app_config_spec.rb
@@ -1,0 +1,159 @@
+require "spec_helper"
+require "climate_control"
+require "pathname"
+
+def with_modified_env(options, &block)
+  ClimateControl.modify(options, &block)
+end
+
+describe OodCore::AppConfig do
+    subject(:config) { described_class.new }
+    let(:default_config_path) { '/etc/ood/config/app_config.yml' }
+    let(:default_erb_wrapper_path) { '/etc/ood/config/bin/erb_wrapper' }
+    let(:fixture_dir) { Pathname.new(__FILE__).dirname.join('fixtures') }
+    let(:alt_config_path) { fixture_dir.join('config/app_config.yml') }
+    let(:alt_erb_wrapper_path) { fixture_dir.join('scripts/erb_wrapper.sh') }
+    let(:fixture_env) { {
+        :OOD_APP_CONFIG => alt_config_path.to_s,
+        :OOD_CONFIG_ERB_WRAPPER => alt_erb_wrapper_path.to_s
+    } }
+
+    context "when OOD_APP_CONFIG is set" do
+        it "loads the alternative configuration" do
+            with_modified_env fixture_env do
+                config.load_config
+            end
+        end
+    end
+
+    context "when OOD_APP_CONFIG is not set" do
+        it "loads the default configuration" do
+            allow(Open3).to receive(
+                :capture3
+            ).with(
+                default_erb_wrapper_path, default_config_path
+            ).and_return([
+                '---', '', double(:success? => true)
+            ])
+
+            config.load_config
+        end
+    end
+
+    context "when unused items exist in the config" do
+        let(:loaded_yaml) {
+            <<~YAML
+            ---
+            not_an_ondemand_config_key: some unnecessary value
+            YAML
+        }
+
+        it "does not crash" do
+            allow(Open3).to receive(
+                :capture3
+            ).with(
+                default_erb_wrapper_path, default_config_path
+            ).and_return([
+                loaded_yaml,'', double(:success? => true)
+            ])
+
+            config.load_config
+        end
+    end
+
+    context "when the fixture config is loaded" do
+        it "has the correct values" do
+            with_modified_env fixture_env do
+                config.load_config
+
+                expect(config.announcement_path).to eq([])
+                expect(config.app_catalog_url).to eq(nil)
+                expect(config.branding_bg_color).to eq('#6CACE4')
+                expect(config.branding_dashboard_header_logo).to eq(nil)
+                expect(config.branding_dashboard_logo).to eq(Pathname.new('/public/logo.png'))
+                expect(config.branding_dashboard_title).to eq('OSC OnDemand')
+                expect(config.branding_link_active_bg_color).to eq('#375C84')
+                expect(config.branding_navbar_type).to eq('inverse')
+                expect(config.default_ssh_host).to eq('owens.osc.edu')
+                expect(config.dev_ssh_host).to eq('ondemand-test.osc.edu')
+                expect(config.disable_safari_basic_auth_warning).to eq(true)
+                expect(config.disable_safari_basic_auth_warning?).to eq(true)
+                expect(config.enable_native_vnc).to eq(true)
+                expect(config.enable_native_vnc?).to eq(true)
+                expect(config.file_upload_max).to eq(10485760000)
+                expect(config.links.is_a? Hash).to be(true)
+                expect(config.links.keys.sort).to eq(['Files', 'Jobs', 'Clusters', 'Interactive Apps', 'Help'].sort)
+                expect(config.load_external_bc_config).to be(false)
+                expect(config.load_external_bc_config?).to be(false)
+                expect(config.load_external_config).to be(false)
+                expect(config.load_external_config?).to be(false)
+                expect(config.locale).to eq('en')
+                expect(config.locales_root).to eq(Pathname.new('/etc/ood/config/locales'))
+                expect(config.motd_format).to eq('osc')
+                expect(config.motd_uri).to eq('file:///etc/motd')
+                expect(config.poll_delay).to eq(10000)
+                expect(config.quota_path).to eq([
+                    Pathname.new('/users/reporting/storage/quota/netapp.netapp-home.ten.osc.edu-users_quota.json'),
+                    Pathname.new('/users/reporting/storage/quota/gpfs.project_quota.json'),
+                    Pathname.new('/users/reporting/storage/quota/gpfs.scratch_quota.json')
+                ])
+                expect(config.show_all_apps_link).to be(true)
+                expect(config.show_all_apps_link?).to be(true)
+                expect(config.show_app_development).to eq(false)
+                expect(config.show_app_development?).to eq(false)
+                expect(config.ssh_hosts).to eq([])
+                expect(config.user_file_system_locations.all?{ |location| location.is_a? Pathname }).to be(true)
+                expect(config.user_file_system_locations.is_a? Array).to be(true)
+                expect(config.whitelist_path).to eq([])
+            end
+        end
+    end
+
+    context "when a blank config is loaded" do
+        it "has the correct defaults" do
+            with_modified_env fixture_env do
+                allow(Open3).to receive(
+                    :capture3
+                ).and_return([
+                    '---', '', double(:success? => true)
+                ])
+                config.load_config
+
+                expect(config.announcement_path).to eq([])
+                expect(config.app_catalog_url).to eq(nil)
+                expect(config.branding_bg_color).to eq('#53565a')
+                expect(config.branding_dashboard_header_logo).to eq(nil)
+                expect(config.branding_dashboard_logo).to eq(nil)
+                expect(config.branding_dashboard_title).to eq('Open OnDemand')
+                expect(config.branding_link_active_bg_color).to eq('#3b3d3f')
+                expect(config.branding_navbar_type).to eq('inverse')
+                expect(config.default_ssh_host).to eq(nil)
+                expect(config.dev_ssh_host).to eq(nil)
+                expect(config.disable_safari_basic_auth_warning).to eq(true)
+                expect(config.disable_safari_basic_auth_warning?).to eq(true)
+                expect(config.enable_native_vnc).to eq(false)
+                expect(config.enable_native_vnc?).to eq(false)
+                expect(config.file_upload_max).to eq(10485760000)
+                expect(config.links.is_a? Hash).to be(true)
+                expect(config.load_external_bc_config).to be(true)
+                expect(config.load_external_bc_config?).to be(true)
+                expect(config.load_external_config).to be(true)
+                expect(config.load_external_config?).to be(true)
+                expect(config.locale).to eq('en')
+                expect(config.locales_root).to eq(Pathname.new('/etc/ood/config/locales'))
+                expect(config.motd_format).to eq(nil)
+                expect(config.motd_uri).to eq(nil)
+                expect(config.poll_delay).to eq(10000)
+                expect(config.quota_path).to eq([])
+                expect(config.show_all_apps_link).to be(false)
+                expect(config.show_all_apps_link?).to be(false)
+                expect(config.show_app_development).to eq(false)
+                expect(config.show_app_development?).to eq(false)
+                expect(config.ssh_hosts).to eq([])
+                expect(config.user_file_system_locations.empty?).to be(true)
+                expect(config.user_file_system_locations.is_a? Array).to be(true)
+                expect(config.whitelist_path).to eq([])
+            end
+        end
+    end
+end

--- a/spec/app_config_spec.rb
+++ b/spec/app_config_spec.rb
@@ -9,34 +9,61 @@ end
 describe OodCore::AppConfig do
     subject(:config) { described_class.new }
     let(:default_config_path) { '/etc/ood/config/app_config.yml' }
-    let(:default_erb_wrapper_path) { '/etc/ood/config/bin/erb_wrapper' }
+    let(:default_config_gen_path) { '/etc/ood/config/bin/config_generator' }
     let(:fixture_dir) { Pathname.new(__FILE__).dirname.join('fixtures') }
     let(:alt_config_path) { fixture_dir.join('config/app_config.yml') }
-    let(:alt_erb_wrapper_path) { fixture_dir.join('scripts/erb_wrapper.sh') }
+    let(:alt_config_gen_path) { fixture_dir.join('scripts/erb_wrapper.sh') }
     let(:fixture_env) { {
         :OOD_APP_CONFIG => alt_config_path.to_s,
-        :OOD_CONFIG_ERB_WRAPPER => alt_erb_wrapper_path.to_s
+        :OOD_CONFIG_GENERATOR => alt_config_gen_path.to_s
     } }
 
     context "when OOD_APP_CONFIG is set" do
         it "loads the alternative configuration" do
             with_modified_env fixture_env do
-                config.load_config
+                described_class.load_config
             end
         end
     end
 
     context "when OOD_APP_CONFIG is not set" do
-        it "loads the default configuration" do
-            allow(Open3).to receive(
-                :capture3
-            ).with(
-                default_erb_wrapper_path, default_config_path
-            ).and_return([
-                '---', '', double(:success? => true)
-            ])
+        it "reads the default configuration file" do
+            expect_any_instance_of(Pathname).to receive(:read).and_return('')
 
-            config.load_config
+            described_class.load_config
+        end
+    end
+
+    context "when an alternative config path is passed" do
+        let(:expected_hash) {{
+            :ssh_hosts => [
+                {'host_name' => 'Owens', 'ssh_host' => 'owens.osc.edu'},
+                {'host_name' => 'Ruby', 'ssh_host' => 'ruby.osc.edu'},
+                {'host_name' => 'Pitzer', 'ssh_host' => 'pitzer.osc.edu'}
+            ],
+            :poll_delay => 5000
+        }}
+        it "returns the correct values" do
+            expect(
+                described_class.load_config(
+                    fixture_dir.join('config/app_config_minimal.yaml')
+                ).to_h
+            ).to include(expected_hash)
+        end
+    end
+
+    context "when no config file is found" do
+        it "raises OodCore::AppConfig::Error" do
+            expect{described_class.load_config}.to raise_error(OodCore::AppConfig::Error)
+        end
+    end
+
+    context "when the config_generator exists but is not executable" do
+        it "raises an OodCore::AppConfig::Error" do
+            expect_any_instance_of(Pathname).to receive(:exist?).and_return(true)
+            expect_any_instance_of(Pathname).to receive(:executable?).and_return(false)
+
+            expect{described_class.load_config}.to raise_error(OodCore::AppConfig::Error)
         end
     end
 
@@ -49,22 +76,61 @@ describe OodCore::AppConfig do
         }
 
         it "does not crash" do
-            allow(Open3).to receive(
-                :capture3
-            ).with(
-                default_erb_wrapper_path, default_config_path
-            ).and_return([
-                loaded_yaml,'', double(:success? => true)
-            ])
+            expect_any_instance_of(Pathname).to receive(:read).and_return(loaded_yaml)
 
-            config.load_config
+            expect(described_class.load_config.raw_config).to eq({'not_an_ondemand_config_key' => 'some unnecessary value'})
+        end
+    end
+
+    context "when #to_h is called on a default config" do
+        let(:expected_hash) {{
+          :announcement_path => [],
+          :app_catalog_url => nil,
+          :app_sharing => false,
+          :app_sharing? => false,
+          :branding_bg_color => "#53565a",
+          :branding_dashboard_header_logo => nil,
+          :branding_dashboard_logo => nil,
+          :branding_dashboard_title => "Open OnDemand",
+          :branding_link_active_bg_color => "#3b3d3f",
+          :branding_navbar_type => "inverse",
+          :default_ssh_host => nil,
+          :dev_ssh_host => nil,
+          :disable_safari_basic_auth_warning => true,
+          :disable_safari_basic_auth_warning? => true,
+          :enable_native_vnc => false,
+          :enable_native_vnc? => false,
+          :file_upload_max => 10485760000,
+          :links => {},
+          :load_external_bc_config => true,
+          :load_external_bc_config? => true,
+          :load_external_config => true,
+          :load_external_config? => true,
+          :locale => "en",
+          :locales_root => Pathname.new("/etc/ood/config/locales"),
+          :motd_format => nil,
+          :motd_uri => nil,
+          :poll_delay => 10000,
+          :quota_path => [],
+          :raw_config => {},
+          :show_all_apps_link => false,
+          :show_all_apps_link? => false,
+          :show_app_development => false,
+          :show_app_development? => false,
+          :ssh_hosts => [],
+          :user_file_system_locations => [],
+          :whitelist_path => []
+        }}
+
+        it "returns the correct Hash" do
+            expect(config.to_h).to eq(expected_hash)
         end
     end
 
     context "when the fixture config is loaded" do
         it "has the correct values" do
             with_modified_env fixture_env do
-                config.load_config
+                config = described_class.load_config
 
                 expect(config.announcement_path).to eq([])
                 expect(config.app_catalog_url).to eq(nil)
@@ -111,49 +177,40 @@ describe OodCore::AppConfig do
 
     context "when a blank config is loaded" do
         it "has the correct defaults" do
-            with_modified_env fixture_env do
-                allow(Open3).to receive(
-                    :capture3
-                ).and_return([
-                    '---', '', double(:success? => true)
-                ])
-                config.load_config
-
-                expect(config.announcement_path).to eq([])
-                expect(config.app_catalog_url).to eq(nil)
-                expect(config.branding_bg_color).to eq('#53565a')
-                expect(config.branding_dashboard_header_logo).to eq(nil)
-                expect(config.branding_dashboard_logo).to eq(nil)
-                expect(config.branding_dashboard_title).to eq('Open OnDemand')
-                expect(config.branding_link_active_bg_color).to eq('#3b3d3f')
-                expect(config.branding_navbar_type).to eq('inverse')
-                expect(config.default_ssh_host).to eq(nil)
-                expect(config.dev_ssh_host).to eq(nil)
-                expect(config.disable_safari_basic_auth_warning).to eq(true)
-                expect(config.disable_safari_basic_auth_warning?).to eq(true)
-                expect(config.enable_native_vnc).to eq(false)
-                expect(config.enable_native_vnc?).to eq(false)
-                expect(config.file_upload_max).to eq(10485760000)
-                expect(config.links.is_a? Hash).to be(true)
-                expect(config.load_external_bc_config).to be(true)
-                expect(config.load_external_bc_config?).to be(true)
-                expect(config.load_external_config).to be(true)
-                expect(config.load_external_config?).to be(true)
-                expect(config.locale).to eq('en')
-                expect(config.locales_root).to eq(Pathname.new('/etc/ood/config/locales'))
-                expect(config.motd_format).to eq(nil)
-                expect(config.motd_uri).to eq(nil)
-                expect(config.poll_delay).to eq(10000)
-                expect(config.quota_path).to eq([])
-                expect(config.show_all_apps_link).to be(false)
-                expect(config.show_all_apps_link?).to be(false)
-                expect(config.show_app_development).to eq(false)
-                expect(config.show_app_development?).to eq(false)
-                expect(config.ssh_hosts).to eq([])
-                expect(config.user_file_system_locations.empty?).to be(true)
-                expect(config.user_file_system_locations.is_a? Array).to be(true)
-                expect(config.whitelist_path).to eq([])
-            end
+            expect(config.announcement_path).to eq([])
+            expect(config.app_catalog_url).to eq(nil)
+            expect(config.branding_bg_color).to eq('#53565a')
+            expect(config.branding_dashboard_header_logo).to eq(nil)
+            expect(config.branding_dashboard_logo).to eq(nil)
+            expect(config.branding_dashboard_title).to eq('Open OnDemand')
+            expect(config.branding_link_active_bg_color).to eq('#3b3d3f')
+            expect(config.branding_navbar_type).to eq('inverse')
+            expect(config.default_ssh_host).to eq(nil)
+            expect(config.dev_ssh_host).to eq(nil)
+            expect(config.disable_safari_basic_auth_warning).to eq(true)
+            expect(config.disable_safari_basic_auth_warning?).to eq(true)
+            expect(config.enable_native_vnc).to eq(false)
+            expect(config.enable_native_vnc?).to eq(false)
+            expect(config.file_upload_max).to eq(10485760000)
+            expect(config.links.is_a? Hash).to be(true)
+            expect(config.load_external_bc_config).to be(true)
+            expect(config.load_external_bc_config?).to be(true)
+            expect(config.load_external_config).to be(true)
+            expect(config.load_external_config?).to be(true)
+            expect(config.locale).to eq('en')
+            expect(config.locales_root).to eq(Pathname.new('/etc/ood/config/locales'))
+            expect(config.motd_format).to eq(nil)
+            expect(config.motd_uri).to eq(nil)
+            expect(config.poll_delay).to eq(10000)
+            expect(config.quota_path).to eq([])
+            expect(config.show_all_apps_link).to be(false)
+            expect(config.show_all_apps_link?).to be(false)
+            expect(config.show_app_development).to eq(false)
+            expect(config.show_app_development?).to eq(false)
+            expect(config.ssh_hosts).to eq([])
+            expect(config.user_file_system_locations.empty?).to be(true)
+            expect(config.user_file_system_locations.is_a? Array).to be(true)
+            expect(config.whitelist_path).to eq([])
         end
     end
 end

--- a/spec/fixtures/config/app_config.yml
+++ b/spec/fixtures/config/app_config.yml
@@ -1,0 +1,260 @@
+# Put custom logic in the front matter
+<%
+user_file_system_locations = [].tap do |paths|
+  # add project space directories
+  projects = `groups`.split.grep(/^P./)
+  paths.concat projects.map { |p| Pathname.new("/fs/project/#{p}")  }
+  # add scratch space directories
+  paths << Pathname.new("/fs/scratch/#{user_name}")
+  paths.concat projects.map { |p| Pathname.new("/fs/scratch/#{p}")  }
+end
+%>
+---
+branding:
+  ## branding.bg_color
+  # Purpose: Color for the navbar's background (CSS colors)
+  # Type: String | null
+  # Replaces: OOD_BRAND_BG_COLOR
+  # Default: #53565a (Grey)
+  bg_color: '#6CACE4'
+  ## branding.link_active_bg_color
+  # Purpose: Color for the navbar links' background when clicked (CSS colors)
+  # Type: String | null
+  # Replaces: OOD_BRAND_LINK_ACTIVE_BG_COLOR
+  # Default: #3b3d3f (Darker grey)
+  link_active_bg_color: '#375C84'
+  ## branding.dashboard_header_logo
+  # Purpose: Specify a logo to display in the header
+  # Type: String | null
+  # Replaces: OOD_DASHBOARD_HEADER_IMG_LOGO
+  # Default: null
+  dashboard_header_logo: null
+  ## branding.dashboard_logo
+  # Purpose: A link to an image to use in the Dashboard's header
+  # Replaces: DISABLE_DASHBOARD_LOGO
+  # Replaces: OOD_DASHBOARD_LOGO
+  # Example: /public/logo.png
+  # Type: String | null
+  # Default: null
+  dashboard_logo: /public/logo.png
+  ## branding.dashboard_title
+  # Purpose: The title for your OnDemand instance; displayed on the Dashboard
+  # Type: String | null
+  # Replaces: OOD_DASHBOARD_TITLE
+  # Default: Open OnDemand
+  dashboard_title: OSC OnDemand
+## default_ssh_host
+# Purpose: Used by the Shell application to provide a default if the URL does
+# not contain a hostname
+#
+#   connects to default_ssh_host
+#     https://example.com/pun/sys/shell/ssh/
+#   connects to sshhost.example.com
+#     https://example.com/pun/sys/shell/ssh/sshhost.example.com
+#
+# Type: String or null
+# Replaces: DEFAULT_SSHHOST
+# Default: none
+default_ssh_host: owens.osc.edu
+## disable_safari_basic_auth_warning
+# Purpose: Show a warning about using Safari, OnDemand, and Apache Basic Auth
+# Type: Boolean
+# Replaces: DISABLE_SAFARI_BASIC_AUTH_WARNING
+# Default: true
+disable_safari_basic_auth_warning: true
+## enable_native_vnc
+# Purpose: Show a panel in the Dashboard session connect view with instructions
+# on how to connect using tools other than the web browser
+# Type: Boolean
+# Replaces: ENABLE_NATIVE_VNC
+# Default: false
+enable_native_vnc: true
+## file_upload_max
+# Purpose: Limit the maximum size of files uploaded through the Files app
+# Type: Integer
+# Replaces: FILE_UPLOAD_MAX
+# Default: 10485760000 (10GB)
+file_upload_max: 10485760000
+motd:
+  ## motd.format
+  # Purpose: Describes the file format of the MOTD file; used to pick the rendering method
+  # Type: String | null
+  # Supported Values:
+  #   - markdown
+  #   - osc
+  #   - rss
+  #   - txt
+  # Replaces: MOTD_FORMAT
+  # Default: txt
+  format: osc
+  ## motd.uri
+  # Purpose: The path to the MOTD file to be displayed
+  #   When the value is null the block is not displayed
+  # Replaces: MOTD_PATH
+  # Type: String | null
+  # Default: null
+  uri: file:///etc/motd
+  ## motd.title
+  # !!Deprecated!!: Use dashboard.motd_title in the locale file instead
+  # Purpose: The title for the MOTD block
+  # Type: String | null
+  # Replaces: MOTD_TITLE
+  # Default: null
+  title: null
+## announcement_path
+# Purpose: The file system path to the announcements
+# Note: Could be an array; we support usage of an announcements.d we could pull from multiple paths
+# Type: Sequence<String> | nil
+# Replaces: OOD_ANNOUNCEMENT_PATH
+# Default: null
+announcement_path: null
+## app_catalog_url
+# Purpose: The link to the external application catalog page
+# Type: String | null
+# Replaces: OOD_APP_CATALOG_URL
+# Default: null
+app_catalog_url: null
+## app_config_root
+# Purpose: The file system path to the default configuration files for specific apps
+# Note:
+# Type: String | null
+# Replaces: OOD_APP_CONFIG_ROOT
+# Default:
+app_config_root: null
+## app_development
+# Purpose: Flag whether the developer view should be shown in the Dashboard
+# Note: Considers whether the development app directory exists in the configured path, or is a symlink; see also OOD_DEV_APPS_ROOT
+# Type: Boolean | null
+# Replaces: OOD_APP_DEVELOPMENT
+# Default: false
+app_development: null
+## APP_SHARING
+# Purpose: Flag whether the app sharing controls should be shown in the Dashboard
+# Type: Boolean | null
+# Replaces: OOD_APP_SHARING
+# Default: false
+app_sharing: false
+## BC_APP_CONFIG_ROOT
+# Purpose: The file system path to the default configuration files for Batch Connect applications
+# Type: String | null
+# Replaces: OOD_BC_APP_CONFIG_ROOT
+# Default: /etc/ood/config/apps
+bc_app_config_root: null
+## dashboard_support_email
+# Purpose: The email address for your site's user support staff
+# Type: String | null
+# Replaces: OOD_DASHBOARD_SUPPORT_EMAIL
+# Default:
+dashboard_support_email: oschelp@osc.edu
+## dev_apps_root
+# Purpose: Contains the path to the user-specific development directory
+# TODO: What sets this? Do we ever want to override it? Is it always user-specific?
+# Type: String | null
+# Replaces: OOD_DEV_APPS_ROOT
+# Default: /dev/null
+dev_apps_root: null
+## dev_ssh_host
+# Purpose: A web node, serving OnDemand, where developers can SSH to perform development work.
+# Type: String | null
+# Replaces: OOD_DEV_SSH_HOST
+# Default: null
+dev_ssh_host: ondemand-test.osc.edu
+## user_file_system_locations
+# Purpose: A list of file system locations that the user has access to
+# Type: Sequence<String> | null
+# Replaces: Custom Rails initializer
+# Default: null
+user_file_system_locations: &user_file_system_locations_ref
+  <% user_file_system_locations.each do |location| %>
+  - <%= location %>
+  <% end %>
+## links
+# Purpose: Define the OnDemand menu
+# Replaces:
+#   - DASHBOARD_2FA_URL
+#   - DASHBOARD_DEV_DOCS_URL
+#   - DASHBOARD_DOCS_URL
+#   - OOD_DASHBOARD_PASSWD_URL
+#   - OOD_DASHBOARD_SUPPORT_URL
+links:
+  Files: null
+  Jobs:
+    - XDMoD: { icon: "https://url/to/xdmod/.png", url: "https://xdmod.osc.edu/" }
+  Clusters: null
+  Interactive Apps: null
+  Help:
+    - Contact Support: { icon: "question-circle", url: "https://www.osc.edu/contact/supercomputing_support" }
+    - Online Documentation: { icon: "info-circle", url: "https://www.osc.edu/ondemand" }
+    - Change HPC Password: { icon: "key", url: "https://my.osc.edu/" }
+## load_external_bc_config
+# Purpose: Flags whether to load external configuration for Batch Connect apps; impacts sub apps
+# TODO: Help me understand sub apps
+# Type: Boolean | null
+# Replaces: OOD_LOAD_EXTERNAL_BC_CONFIG
+# Default: true
+load_external_bc_config: false
+## load_external_config
+# Purpose: Flags whether to load external configuration; includes initializers, and custom views
+# Type: Boolean | null
+# Replaces: OOD_LOAD_EXTERNAL_CONFIG
+# Default: true
+load_external_config: false
+## locale
+# Purpose: Sets the locale/translation to use
+# Type: String | null
+# Replaces: OOD_LOCALE
+# Default: en
+locale: null
+## locales_root
+# Purpose: File system path where localizations are stored
+# Type: String | null
+# Replaces: OOD_LOCALES_ROOT
+# Default: /etc/ood/config/locales
+locales_root: null
+## navbar_type
+# Purpose: The Boostrap navbar specialization
+# Type: String | null
+# Replaces: OOD_NAVBAR_TYPE
+# Default: inverse
+navbar_type: null
+## quota_path
+# Purpose: The file or list of files used to specify the user's file system usage
+# Type: Sequence<String> | null
+# Replaces: OOD_QUOTA_PATH
+# Default: null
+quota_path:
+  - /users/reporting/storage/quota/netapp.netapp-home.ten.osc.edu-users_quota.json
+  - /users/reporting/storage/quota/gpfs.project_quota.json
+  - /users/reporting/storage/quota/gpfs.scratch_quota.json
+## SSH_HOSTS
+# Purpose: Declares SSH hosts for apps
+#   Used by the Files app
+# Type: Sequence<Mapping<>> | null
+# Example:
+# - ssh_host: owens.osc.edu
+#   host_name: Owens
+# - ssh_host: ruby.osc.edu
+#   host_name: Ruby
+# - ssh_host: pitzer.osc.edu
+#   host_name: Pitzer
+# Replaces: OOD_SSH_HOSTS
+# Default: null
+ssh_hosts: null
+## poll_delay
+# Purpose: The Dashboard app's polling interval (milliseconds) used when checking for active Batch Connect sessions
+# Type: Integer | null
+# Replaces: POLL_DELAY
+# Default: 10000ms
+poll_delay: null
+## show_all_apps_link
+# Purpose: Flags whether to show the all apps page in the Dashboard
+# Type: Boolean
+# Replaces: SHOW_ALL_APPS_LINK
+# Default: false
+show_all_apps_link: true
+## whitelist_path
+# Purpose: A list of path roots that users are restricted to accessing using the Files app
+# Type: Sequence<String> | null
+# Replaces: WHITELIST_PATH
+# Default: null
+whitelist_path: null

--- a/spec/fixtures/config/app_config.yml
+++ b/spec/fixtures/config/app_config.yml
@@ -5,7 +5,7 @@ user_file_system_locations = [].tap do |paths|
   projects = `groups`.split.grep(/^P./)
   paths.concat projects.map { |p| Pathname.new("/fs/project/#{p}")  }
   # add scratch space directories
-  paths << Pathname.new("/fs/scratch/#{user_name}")
+  paths << Pathname.new("/fs/scratch/#{ENV['USER']}")
   paths.concat projects.map { |p| Pathname.new("/fs/scratch/#{p}")  }
 end
 %>

--- a/spec/fixtures/config/app_config_minimal.yaml
+++ b/spec/fixtures/config/app_config_minimal.yaml
@@ -1,0 +1,27 @@
+---
+## SSH_HOSTS
+# Purpose: Declares SSH hosts for apps
+#   Used by the Files app
+# Type: Sequence<Mapping<>> | null
+# Example:
+# - ssh_host: owens.osc.edu
+#   host_name: Owens
+# - ssh_host: ruby.osc.edu
+#   host_name: Ruby
+# - ssh_host: pitzer.osc.edu
+#   host_name: Pitzer
+# Replaces: OOD_SSH_HOSTS
+# Default: null
+ssh_hosts:
+- ssh_host: owens.osc.edu
+  host_name: Owens
+- ssh_host: ruby.osc.edu
+  host_name: Ruby
+- ssh_host: pitzer.osc.edu
+  host_name: Pitzer
+## poll_delay
+# Purpose: The Dashboard app's polling interval (milliseconds) used when checking for active Batch Connect sessions
+# Type: Integer | null
+# Replaces: POLL_DELAY
+# Default: 10000ms
+poll_delay: 5000

--- a/spec/fixtures/scripts/erb_wrapper.sh
+++ b/spec/fixtures/scripts/erb_wrapper.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+# This would be site defined
+exec erb -r pathname user_name="$USER" home="$HOME" "$@"

--- a/spec/fixtures/scripts/erb_wrapper.sh
+++ b/spec/fixtures/scripts/erb_wrapper.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 # This would be site defined
-exec erb -r pathname user_name="$USER" home="$HOME" "$@"
+exec erb -r pathname "$@"


### PR DESCRIPTION
Added to ood_core because ood_appkit requires Rails which is not the base framework for all our apps.

* Supports programmatic configuration using ERB defaults to `/etc/ood/config/bin/erb_wrapper`
* Reacts well to options missing from the config



┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201735133575781/1201737436582662) by [Unito](https://www.unito.io)
