### PR TITLE
fail fast if nc is not installed and indicate that it isn't installed

### DIFF
--- a/lib/ood_core/batch_connect/template.rb
+++ b/lib/ood_core/batch_connect/template.rb
@@ -121,7 +121,13 @@ module OodCore
                 port_used () {
                   local port="${1#*:}"
                   local host=$((expr "${1}" : '\\(.*\\):' || echo "localhost") | awk 'END{print $NF}')
-                  nc -w 2 "${host}" "${port}" < /dev/null > /dev/null 2>&1
+                  if command -v nc >/dev/null 2>&1; then
+                    nc -w 2 "${host}" "${port}" < /dev/null > /dev/null 2>&1
+                  elif command -v lsof >/dev/null 2>&1; then
+                    lsof -i :"${port}" >/dev/null 2>&1
+                  else
+                    return 127
+                  fi
                 }
                 export -f port_used
 
@@ -148,7 +154,8 @@ module OodCore
                     if [ "$port_status" == "0" ]; then
                       return 0
                     elif [ "$port_status" == "127" ]; then
-                       echo "nc command not found, please install it! exiting 127"
+                       echo "command to find port not found, please install it! exiting 127"
+                       echo "command options are lsof or nc"
                        return 127
                     fi
                     sleep 0.5

--- a/lib/ood_core/batch_connect/template.rb
+++ b/lib/ood_core/batch_connect/template.rb
@@ -127,6 +127,8 @@ module OodCore
                     lsof -i :"${port}" >/dev/null 2>&1
                   elif "$SHELL" == "/bin/bash"; then
                     (: < /dev/tcp/127.0.0.1/8081) >/dev/null 2>&1
+                  elif command -v python >/dev/null 2>&1; then
+                    python -c "import socket; socket.socket().connect(('$host',$port))" >/dev/null 2>&1
                   else
                     return 127
                   fi
@@ -157,7 +159,7 @@ module OodCore
                       return 0
                     elif [ "$port_status" == "127" ]; then
                        echo "command to find port not found, please install it! exiting 127"
-                       echo "command options are lsof, nc or bash's /dev/tcp"
+                       echo "command options are lsof, nc, bash's /dev/tcp, or python with socket lib"
                        return 127
                     fi
                     sleep 0.5

--- a/lib/ood_core/batch_connect/template.rb
+++ b/lib/ood_core/batch_connect/template.rb
@@ -125,6 +125,8 @@ module OodCore
                     nc -w 2 "${host}" "${port}" < /dev/null > /dev/null 2>&1
                   elif command -v lsof >/dev/null 2>&1; then
                     lsof -i :"${port}" >/dev/null 2>&1
+                  elif "$SHELL" == "/bin/bash"; then
+                    (: < /dev/tcp/127.0.0.1/8081) >/dev/null 2>&1
                   else
                     return 127
                   fi
@@ -155,7 +157,7 @@ module OodCore
                       return 0
                     elif [ "$port_status" == "127" ]; then
                        echo "command to find port not found, please install it! exiting 127"
-                       echo "command options are lsof or nc"
+                       echo "command options are lsof, nc or bash's /dev/tcp"
                        return 127
                     fi
                     sleep 0.5

--- a/lib/ood_core/batch_connect/template.rb
+++ b/lib/ood_core/batch_connect/template.rb
@@ -121,7 +121,7 @@ module OodCore
                 port_used () {
                   local port="${1#*:}"
                   local host=$((expr "${1}" : '\\(.*\\):' || echo "localhost") | awk 'END{print $NF}')
-                  nc -w 2 "${host}" "${port}" < /dev/null &> /dev/null
+                  nc -w 2 "${host}" "${port}" < /dev/null > /dev/null 2>&1
                 }
                 export -f port_used
 
@@ -143,8 +143,13 @@ module OodCore
                   local port="${1}"
                   local time="${2:-30}"
                   for ((i=1; i<=time*2; i++)); do
-                    if port_used "${port}"; then
+                    port_used "${port}"
+                    port_status=$?
+                    if [ "$port_status" == "0" ]; then
                       return 0
+                    elif [ "$port_status" == "127" ]; then
+                       echo "nc command not found, please install it! exiting 127"
+                       return 127
                     fi
                     sleep 0.5
                   done

--- a/lib/ood_core/batch_connect/template.rb
+++ b/lib/ood_core/batch_connect/template.rb
@@ -163,8 +163,8 @@ module OodCore
                     if [ "$port_status" == "0" ]; then
                       return 0
                     elif [ "$port_status" == "127" ]; then
-                       echo "command to find port not found, please install it! exiting 127"
-                       echo "command options are lsof, nc, bash's /dev/tcp, or python with socket lib"
+                       echo "commands to find port were either not found or inaccessible."
+                       echo "command options are lsof, nc, bash's /dev/tcp, or python (or python3) with socket lib."
                        return 127
                     fi
                     sleep 0.5

--- a/lib/ood_core/batch_connect/template.rb
+++ b/lib/ood_core/batch_connect/template.rb
@@ -125,7 +125,7 @@ module OodCore
                     nc -w 2 "${host}" "${port}" < /dev/null > /dev/null 2>&1
                   elif command -v lsof >/dev/null 2>&1; then
                     lsof -i :"${port}" >/dev/null 2>&1
-                  elif "$SHELL" == "/bin/bash"; then
+                  elif [ -n "$SHELL" ] && [ "$SHELL" = "/bin/bash" ]; then
                     (: < /dev/tcp/127.0.0.1/8081) >/dev/null 2>&1
                   elif command -v python >/dev/null 2>&1; then
                     python -c "import socket; socket.socket().connect(('$host',$port))" >/dev/null 2>&1

--- a/lib/ood_core/batch_connect/template.rb
+++ b/lib/ood_core/batch_connect/template.rb
@@ -116,14 +116,13 @@ module OodCore
                   shuf -i ${1}-${2} -n 1
                 }
                 export -f random_number
-                export python_socket_cmd="import socket; socket.socket().connect(('$1',$2))"
 
                 port_used_python() {
-                  python -c "$python_socket_cmd" >/dev/null 2>&1
+                  python -c "import socket; socket.socket().connect(('$1',$2))" >/dev/null 2>&1
                 }
 
                 port_used_python3() {
-                  python3 -c "$python_socket_cmd" >/dev/null 2>&1
+                  python3 -c "import socket; socket.socket().connect(('$1',$2))" >/dev/null 2>&1
                 }
 
                 port_used_nc(){

--- a/lib/ood_core/batch_connect/template.rb
+++ b/lib/ood_core/batch_connect/template.rb
@@ -133,7 +133,7 @@ module OodCore
                   elif python3 -h >/dev/null 2>&1; then
                     python3 -c "$python_cmd" >/dev/null 2>&1
                   elif [ "$bash_supported" == "/dev/tcp/*/*" ]; then
-                    (: < /dev/tcp/127.0.0.1/8081) >/dev/null 2>&1
+                    (: < /dev/tcp/${host}/${port}) >/dev/null 2>&1
                   else
                     return 127
                   fi


### PR DESCRIPTION
Clearly most sites don't already have nc installed.  This will actually tell them that it isn't installed.

I was able to test with, commenting out nc and adding the 'notfound' command.

```bash
    #nc -w 2 "${host}" "${port}" < /dev/null > /dev/null 2>&1
    notfound >/dev/null 2>&1
```