### PR TITLE
Add directive_prefix to all adapters

### DIFF
--- a/lib/ood_core/job/adapter.rb
+++ b/lib/ood_core/job/adapter.rb
@@ -36,7 +36,7 @@ module OodCore
       # Retrieve info for all jobs from the resource manager
       # @abstract Subclass is expected to implement {#info_all}
       # @raise [NotImplementedError] if subclass did not define {#info_all}
-      # @param attrs [Array<symbol>] defaults to nil (and all attrs are provided) 
+      # @param attrs [Array<symbol>] defaults to nil (and all attrs are provided)
       #   This array specifies only attrs you want, in addition to id and status.
       #   If an array, the Info object that is returned to you is not guarenteed
       #   to have a value for any attr besides the ones specified and id and status.
@@ -51,7 +51,7 @@ module OodCore
       # Retrieve info for all jobs for a given owner or owners from the
       # resource manager
       # @param owner [#to_s, Array<#to_s>] the owner(s) of the jobs
-      # @param attrs [Array<symbol>] defaults to nil (and all attrs are provided) 
+      # @param attrs [Array<symbol>] defaults to nil (and all attrs are provided)
       #   This array specifies only attrs you want, in addition to id and status.
       #   If an array, the Info object that is returned to you is not guarenteed
       #   to have a value for any attr besides the ones specified and id and status.
@@ -69,7 +69,7 @@ module OodCore
       end
 
       # Iterate over each job Info object
-      # @param attrs [Array<symbol>] defaults to nil (and all attrs are provided) 
+      # @param attrs [Array<symbol>] defaults to nil (and all attrs are provided)
       #   This array specifies only attrs you want, in addition to id and status.
       #   If an array, the Info object that is returned to you is not guarenteed
       #   to have a value for any attr besides the ones specified and id and status.
@@ -88,7 +88,7 @@ module OodCore
 
       # Iterate over each job Info object
       # @param owner [#to_s, Array<#to_s>] the owner(s) of the jobs
-      # @param attrs [Array<symbol>] defaults to nil (and all attrs are provided) 
+      # @param attrs [Array<symbol>] defaults to nil (and all attrs are provided)
       #   This array specifies only attrs you want, in addition to id and status.
       #   If an array, the Info object that is returned to you is not guarenteed
       #   to have a value for any attr besides the ones specified and id and status.
@@ -158,6 +158,16 @@ module OodCore
         raise NotImplementedError, "subclass did not define #delete"
       end
 
+      # Return the scheduler-specific directive prefix
+      #
+      # Examples of directive prefixes include #QSUB, #BSUB and allow placing what would
+      # otherwise be command line options inside the job launch script.
+      #
+      # The method should return nil if the adapter does not support prefixes
+      #
+      # @abstract Subclass is expected to implement {#directive_prefix}
+      # @raise [NotImplementedError] if subclass did not defined {#directive_prefix}
+      # @return [String]
       def directive_prefix
         raise NotImplementedError, "subclass did not define #directive_prefix"
       end

--- a/lib/ood_core/job/adapter.rb
+++ b/lib/ood_core/job/adapter.rb
@@ -157,6 +157,10 @@ module OodCore
       def delete(id)
         raise NotImplementedError, "subclass did not define #delete"
       end
+
+      def directive_prefix
+        raise NotImplementedError, "subclass did not define #directive_prefix"
+      end
     end
   end
 end

--- a/lib/ood_core/job/adapters/linux_host.rb
+++ b/lib/ood_core/job/adapters/linux_host.rb
@@ -202,7 +202,7 @@ module OodCore
         end
 
         def directive_prefix
-          raise JobAdapterError, "The LinuxHost adapter does not support directive prefixes"
+          nil
         end
 
         private

--- a/lib/ood_core/job/adapters/linux_host.rb
+++ b/lib/ood_core/job/adapters/linux_host.rb
@@ -201,6 +201,10 @@ module OodCore
           raise JobAdapterError, e.message
         end
 
+        def directive_prefix
+          raise JobAdapterError, "The LinuxHost adapter does not support directive prefixes"
+        end
+
         private
 
         def host_permitted?(destination_host)

--- a/lib/ood_core/job/adapters/lsf.rb
+++ b/lib/ood_core/job/adapters/lsf.rb
@@ -167,6 +167,10 @@ module OodCore
           raise JobAdapterError, e.message
         end
 
+        def directive_prefix
+          '#BSUB'
+        end
+
         private
           # Determine state from LSF state code
           def get_state(st)

--- a/lib/ood_core/job/adapters/pbspro.rb
+++ b/lib/ood_core/job/adapters/pbspro.rb
@@ -397,6 +397,10 @@ module OodCore
           raise JobAdapterError, e.message unless /Unknown Job Id/ =~ e.message || /Job has finished/ =~ e.message
         end
 
+        def directive_prefix
+          '#PBS'
+        end
+
         private
           # Convert duration to seconds
           def duration_in_seconds(time)

--- a/lib/ood_core/job/adapters/sge.rb
+++ b/lib/ood_core/job/adapters/sge.rb
@@ -157,6 +157,10 @@ module OodCore
         rescue Batch::Error => e
           raise JobAdapterError, e.message
         end
+
+        def directive_prefix
+          '#$'
+        end
       end
     end
   end

--- a/lib/ood_core/job/adapters/slurm.rb
+++ b/lib/ood_core/job/adapters/slurm.rb
@@ -530,6 +530,10 @@ module OodCore
           raise JobAdapterError, e.message unless /Invalid job id specified/ =~ e.message
         end
 
+        def directive_prefix
+          '#SBATCH'
+        end
+
         private
           # Convert duration to seconds
           def duration_in_seconds(time)

--- a/lib/ood_core/job/adapters/torque.rb
+++ b/lib/ood_core/job/adapters/torque.rb
@@ -288,6 +288,10 @@ module OodCore
           raise JobAdapterError, e.message
         end
 
+        def directive_prefix
+          '#QSUB'
+        end
+
         private
           # Convert duration to seconds
           def duration_in_seconds(time)

--- a/spec/job/adapter_spec.rb
+++ b/spec/job/adapter_spec.rb
@@ -12,6 +12,7 @@ describe OodCore::Job::Adapter do
   it { is_expected.to respond_to(:hold).with(1).argument }
   it { is_expected.to respond_to(:release).with(1).argument }
   it { is_expected.to respond_to(:delete).with(1).argument }
+  it { is_expected.to respond_to(:directive_prefix).with(0).arguments }
 
   describe "#submit" do
     context "when script not defined" do

--- a/spec/job/adapters/linux_host_spec.rb
+++ b/spec/job/adapters/linux_host_spec.rb
@@ -315,8 +315,8 @@ describe OodCore::Job::Adapters::LinuxHost do
 
     describe "#directive_prefix" do
       context "when called" do
-        it "raises an Error" do
-          expect { adapter.directive_prefix }.to raise_error(OodCore::JobAdapterError)
+        it "returns nil" do
+          expect(adapter.directive_prefix).to eq(nil)
         end
       end
     end

--- a/spec/job/adapters/linux_host_spec.rb
+++ b/spec/job/adapters/linux_host_spec.rb
@@ -134,6 +134,7 @@ describe OodCore::Job::Adapters::LinuxHost do
         is_expected.to respond_to(:release).with(1).argument
         is_expected.to respond_to(:delete).with(1).argument
         is_expected.to respond_to(:supports_job_arrays?)
+        is_expected.to respond_to(:directive_prefix).with(0).arguments
     end
 
     it "does not support job arrays" do
@@ -310,5 +311,13 @@ describe OodCore::Job::Adapters::LinuxHost do
             expect { adapter.delete('jobid@owens-login01.hpc.osc.edu') }.to raise_error(OodCore::JobAdapterError)
           end
         end
+    end
+
+    describe "#directive_prefix" do
+      context "when called" do
+        it "raises an Error" do
+          expect { adapter.directive_prefix }.to raise_error(OodCore::JobAdapterError)
+        end
+      end
     end
 end

--- a/spec/job/adapters/lsf_spec.rb
+++ b/spec/job/adapters/lsf_spec.rb
@@ -14,6 +14,7 @@ describe OodCore::Job::Adapters::Lsf do
   it { is_expected.to respond_to(:hold).with(1).argument }
   it { is_expected.to respond_to(:release).with(1).argument }
   it { is_expected.to respond_to(:delete).with(1).argument }
+  it { is_expected.to respond_to(:directive_prefix).with(0).arguments }
 
   it "claims to support job arrays" do
     expect(subject.supports_job_arrays?).to be_truthy
@@ -330,4 +331,12 @@ describe OodCore::Job::Adapters::Lsf do
       )
     end
   end
+
+  describe "#directive_prefix" do
+      context "when called" do
+        it "does not raise an error" do
+          expect { adapter.directive_prefix }.not_to raise_error
+        end
+      end
+    end
 end

--- a/spec/job/adapters/pbspro_spec.rb
+++ b/spec/job/adapters/pbspro_spec.rb
@@ -17,6 +17,7 @@ describe OodCore::Job::Adapters::PBSPro do
   it { is_expected.to respond_to(:hold).with(1).argument }
   it { is_expected.to respond_to(:release).with(1).argument }
   it { is_expected.to respond_to(:delete).with(1).argument }
+  it { is_expected.to respond_to(:directive_prefix).with(0).arguments }
 
   it "claims to support job arrays" do
     expect(subject.supports_job_arrays?).to be_truthy
@@ -773,4 +774,12 @@ describe OodCore::Job::Adapters::PBSPro do
       end
     end
   end
+
+  describe "#directive_prefix" do
+      context "when called" do
+        it "does not raise an error" do
+          expect { adapter.directive_prefix }.not_to raise_error
+        end
+      end
+    end
 end

--- a/spec/job/adapters/sge_spec.rb
+++ b/spec/job/adapters/sge_spec.rb
@@ -14,6 +14,7 @@ describe OodCore::Job::Adapters::Sge do
   it { is_expected.to respond_to(:hold).with(1).argument }
   it { is_expected.to respond_to(:release).with(1).argument }
   it { is_expected.to respond_to(:delete).with(1).argument }
+  it { is_expected.to respond_to(:directive_prefix).with(0).arguments }
 
   it "claims to support job arrays" do
     expect(subject.supports_job_arrays?).to be_truthy
@@ -205,4 +206,12 @@ describe "#submit" do
 
   describe "#info" do
   end
+
+  describe "#directive_prefix" do
+      context "when called" do
+        it "does not raise an error" do
+          expect { adapter.directive_prefix }.not_to raise_error
+        end
+      end
+    end
 end

--- a/spec/job/adapters/slurm_spec.rb
+++ b/spec/job/adapters/slurm_spec.rb
@@ -16,6 +16,7 @@ describe OodCore::Job::Adapters::Slurm do
   it { is_expected.to respond_to(:hold).with(1).argument }
   it { is_expected.to respond_to(:release).with(1).argument }
   it { is_expected.to respond_to(:delete).with(1).argument }
+  it { is_expected.to respond_to(:directive_prefix).with(0).arguments }
 
   it "claims to support job arrays" do
     expect(subject.supports_job_arrays?).to be_truthy
@@ -1089,6 +1090,14 @@ describe OodCore::Job::Adapters::Slurm do
 
         OodCore::Job::Adapters::Slurm.new(slurm: batch).submit script
         expect(Open3).to have_received(:capture3).with(anything, "not_sbatch", any_args)
+      end
+    end
+  end
+
+  describe "#directive_prefix" do
+    context "when called" do
+      it "does not raise an error" do
+        expect { adapter.directive_prefix }.not_to raise_error
       end
     end
   end

--- a/spec/job/adapters/torque_spec.rb
+++ b/spec/job/adapters/torque_spec.rb
@@ -16,6 +16,7 @@ describe OodCore::Job::Adapters::Torque do
   it { is_expected.to respond_to(:hold).with(1).argument }
   it { is_expected.to respond_to(:release).with(1).argument }
   it { is_expected.to respond_to(:delete).with(1).argument }
+  it { is_expected.to respond_to(:directive_prefix).with(0).arguments }
 
   it "claims to support job arrays" do
     expect(subject.supports_job_arrays?).to be_truthy
@@ -914,6 +915,14 @@ describe OodCore::Job::Adapters::Torque do
       before { expect(pbs).to receive(:delete_job).and_raise(Torque::FFI::BadstateError) }
 
       it { is_expected.to eq(nil) }
+    end
+  end
+
+  describe "#directive_prefix" do
+    context "when called" do
+      it "does not raise an error" do
+        expect { adapter.directive_prefix }.not_to raise_error
+      end
     end
   end
 end


### PR DESCRIPTION
Adapters which do not support directive_prefix (such as the LinuxHost) are expected to raise JobAdapterError instead of NotImplementedError.

Fixes #161.