### PR TITLE
Catch expections in parsing bad and empty cluster files

### DIFF
--- a/lib/ood_core.rb
+++ b/lib/ood_core.rb
@@ -2,6 +2,7 @@ require "ood_core/version"
 require "ood_core/errors"
 require "ood_core/cluster"
 require "ood_core/clusters"
+require "ood_core/invalid_cluster"
 
 # The main namespace for ood_core
 module OodCore

--- a/lib/ood_core/cluster.rb
+++ b/lib/ood_core/cluster.rb
@@ -159,6 +159,12 @@ module OodCore
       }
     end
 
+    # This cluster is always valid
+    # @return true
+    def valid?
+      return true
+    end
+
     private
       # Build acl adapter objects from array
       def build_acls(ary)

--- a/lib/ood_core/cluster.rb
+++ b/lib/ood_core/cluster.rb
@@ -28,6 +28,10 @@ module OodCore
     # @return [Hash] the acls configuration
     attr_reader :acls_config
 
+    # The errors encountered with configuring this cluster
+    # @return Array<String> the errors
+    attr_reader :errors
+
     # @param cluster [#to_h] the cluster object
     # @option cluster [#to_sym] :id The cluster id
     # @option cluster [#to_h] :metadata ({}) The cluster's metadata
@@ -39,6 +43,8 @@ module OodCore
     #   against
     # @option cluster [#to_h] :batch_connect ({}) Configuration for batch
     #   connect templates
+    # @option cluster [#to_a] :errors ([]) List of configuration errors
+    #
     def initialize(cluster)
       c = cluster.to_h.symbolize_keys
 
@@ -52,6 +58,9 @@ module OodCore
       @custom_config   = c.fetch(:custom, {})  .to_h.symbolize_keys
       @acls_config     = c.fetch(:acls, [])    .map(&:to_h)
       @batch_connect_config = c.fetch(:batch_connect, {}).to_h.symbolize_keys
+
+      # side affects from object creation and validation
+      @errors          = c.fetch(:errors, [])  .to_a
     end
 
     # Metadata that provides extra information about this cluster

--- a/lib/ood_core/clusters.rb
+++ b/lib/ood_core/clusters.rb
@@ -22,7 +22,7 @@ module OodCore
           if config.readable?
             CONFIG_VERSION.any? do |version|
               begin
-                YAML.safe_load(config.read).fetch(version, {}).each do |k, v|
+                YAML.safe_load(config.read)&.fetch(version, {}).each do |k, v|
                   clusters << Cluster.new(send("parse_#{version}", id: k, cluster: v))
                 end
               rescue Psych::SyntaxError => e
@@ -37,7 +37,7 @@ module OodCore
           Pathname.glob([config.join("*.yml"), config.join("*.yaml")]).select(&:file?).select(&:readable?).each do |p|
             CONFIG_VERSION.any? do |version|
               begin
-                if cluster = YAML.safe_load(p.read).fetch(version, nil)
+                if cluster = YAML.safe_load(p.read)&.fetch(version, nil)
                   clusters << Cluster.new(send("parse_#{version}", id: p.basename(p.extname()).to_s, cluster: cluster))
                 end
               rescue Psych::SyntaxError => e

--- a/lib/ood_core/clusters.rb
+++ b/lib/ood_core/clusters.rb
@@ -21,16 +21,30 @@ module OodCore
         if config.file?
           if config.readable?
             CONFIG_VERSION.any? do |version|
-              YAML.safe_load(config.read).fetch(version, {}).each do |k, v|
-                clusters << Cluster.new(send("parse_#{version}", id: k, cluster: v))
+              begin
+                YAML.safe_load(config.read).fetch(version, {}).each do |k, v|
+                  clusters << Cluster.new(send("parse_#{version}", id: k, cluster: v))
+                end
+              rescue Psych::SyntaxError => e
+                clusters << InvalidCluster.new(
+                  id: config.basename(config.extname).to_s,
+                  metadata: { error_msg: e.message.to_s }
+                )
               end
             end
           end
         elsif config.directory?
           Pathname.glob([config.join("*.yml"), config.join("*.yaml")]).select(&:file?).select(&:readable?).each do |p|
             CONFIG_VERSION.any? do |version|
-              if cluster = YAML.safe_load(p.read).fetch(version, nil)
-                clusters << Cluster.new(send("parse_#{version}", id: p.basename(p.extname()).to_s, cluster: cluster))
+              begin
+                if cluster = YAML.safe_load(p.read).fetch(version, nil)
+                  clusters << Cluster.new(send("parse_#{version}", id: p.basename(p.extname()).to_s, cluster: cluster))
+                end
+              rescue Psych::SyntaxError => e
+                clusters << InvalidCluster.new(
+                  id: p.basename(p.extname).to_s,
+                  metadata: { error_msg: e.message.to_s }
+                )
               end
             end
           end

--- a/lib/ood_core/clusters.rb
+++ b/lib/ood_core/clusters.rb
@@ -28,7 +28,7 @@ module OodCore
               rescue Psych::SyntaxError => e
                 clusters << InvalidCluster.new(
                   id: config.basename(config.extname).to_s,
-                  metadata: { error_msg: e.message.to_s }
+                  errors: [ e.message.to_s ]
                 )
               end
             end
@@ -43,7 +43,7 @@ module OodCore
               rescue Psych::SyntaxError => e
                 clusters << InvalidCluster.new(
                   id: p.basename(p.extname).to_s,
-                  metadata: { error_msg: e.message.to_s }
+                  errors: [ e.message.to_s ]
                 )
               end
             end

--- a/lib/ood_core/invalid_cluster.rb
+++ b/lib/ood_core/invalid_cluster.rb
@@ -27,5 +27,11 @@ module OodCore
     def allow?
       false
     end
+
+    # This cluster is never valid
+    # @return false
+    def valid?
+      return false
+    end
   end
 end

--- a/lib/ood_core/invalid_cluster.rb
+++ b/lib/ood_core/invalid_cluster.rb
@@ -1,0 +1,31 @@
+module OodCore
+  # A special case of an OodCore::Cluster where something went awry in the
+  # creation and it's invalid for some reason.  Users should only be able
+  # to rely on id and metadata.error_msg. All *allow? related functions
+  # false, meaning nothing is allowed.
+  class InvalidCluster < Cluster
+    # Jobs are not allowed
+    # @return false
+    def login_allow?
+      false
+    end
+
+    # Jobs are not allowed
+    # @return false
+    def job_allow?
+      false
+    end
+
+    # Custom features are not allowed
+    # @return false
+    def custom_allow?(_)
+      false
+    end
+
+    # This cluster is not allowed to be used
+    # @return false
+    def allow?
+      false
+    end
+  end
+end

--- a/spec/clusters_spec.rb
+++ b/spec/clusters_spec.rb
@@ -1,6 +1,10 @@
 require "spec_helper"
 require "pathname"
 
+def malformed_msg
+  "(<unknown>): mapping values are not allowed in this context at line 5 column 8"
+end
+
 describe OodCore::Clusters do
   describe "#load_file" do
     context "when loading a valid file" do
@@ -41,15 +45,17 @@ describe OodCore::Clusters do
         end
       end
 
-      it "correctly populates of invalid clusters' id and metadata" do
+      it "correctly populates of invalid clusters' id and errors" do
         clusters = OodCore::Clusters.load_file(config)
         clusters.each do |cluster|
           if cluster.id.to_s == 'malformed'
             id = cluster.id.to_s
-            error_msg = cluster.metadata.error_msg.to_s
   
             expect(id).to eql('malformed')
-            expect(error_msg).not_to be_empty
+            expect(cluster.errors.size).to eql(1)
+            expect(cluster.errors[0]).to eql(malformed_msg)
+          else
+            expect(cluster.errors).to be_empty
           end
         end
       end
@@ -106,11 +112,11 @@ describe OodCore::Clusters do
         clusters = OodCore::Clusters.load_file(config)
         clusters.each do |cluster|
           id = cluster.id.to_s
-          error_msg = cluster.metadata.error_msg.to_s
 
           expect(id).to eql('malformed')
-          expect(error_msg).not_to be_empty
           expect(cluster.valid?).to eql(false)
+          expect(cluster.errors.size).to eql(1)
+          expect(cluster.errors[0]).to eql(malformed_msg)
         end
       end
     end

--- a/spec/clusters_spec.rb
+++ b/spec/clusters_spec.rb
@@ -33,8 +33,10 @@ describe OodCore::Clusters do
         clusters.each do |cluster|
           if cluster.id.to_s == 'malformed'
             expect(cluster).to be_an_instance_of(OodCore::InvalidCluster)
+            expect(cluster.valid?).to eql(false)
           else
             expect(cluster).to be_an_instance_of(OodCore::Cluster)
+            expect(cluster.valid?).to eql(true)
           end
         end
       end
@@ -96,6 +98,7 @@ describe OodCore::Clusters do
         clusters = OodCore::Clusters.load_file(config)
         clusters.each do |cluster|
           expect(cluster).to be_an_instance_of(OodCore::InvalidCluster)
+          expect(cluster.valid?).to eql(false)
         end
       end
 
@@ -107,6 +110,7 @@ describe OodCore::Clusters do
 
           expect(id).to eql('malformed')
           expect(error_msg).not_to be_empty
+          expect(cluster.valid?).to eql(false)
         end
       end
     end

--- a/spec/clusters_spec.rb
+++ b/spec/clusters_spec.rb
@@ -25,13 +25,30 @@ describe OodCore::Clusters do
       end
     end
 
-    context "when loading directory of valid cluster config" do
+    context "when loading directory of cluster configs" do
       let(:config) { Pathname.pwd + 'spec/fixtures/config/clusters.d'}
 
       it "returns an array of OodCore::Cluster" do
         clusters = OodCore::Clusters.load_file(config)
         clusters.each do |cluster|
-          expect(cluster).to be_an_instance_of(OodCore::Cluster)
+          if cluster.id.to_s == 'malformed'
+            expect(cluster).to be_an_instance_of(OodCore::InvalidCluster)
+          else
+            expect(cluster).to be_an_instance_of(OodCore::Cluster)
+          end
+        end
+      end
+
+      it "correctly populates of invalid clusters' id and metadata" do
+        clusters = OodCore::Clusters.load_file(config)
+        clusters.each do |cluster|
+          if cluster.id.to_s == 'malformed'
+            id = cluster.id.to_s
+            error_msg = cluster.metadata.error_msg.to_s
+  
+            expect(id).to eql('malformed')
+            expect(error_msg).not_to be_empty
+          end
         end
       end
     end
@@ -71,5 +88,28 @@ describe OodCore::Clusters do
         expect { OodCore::Clusters.load_file(config) }.to raise_error(OodCore::ConfigurationNotFound)
       end
     end
+
+    context "when loading a single malformed .yml" do
+      let(:config) { Pathname.pwd + 'spec/fixtures/config/clusters.d/malformed.yml'}
+
+      it "returns an array of OodCore::InvalidCluster" do
+        clusters = OodCore::Clusters.load_file(config)
+        clusters.each do |cluster|
+          expect(cluster).to be_an_instance_of(OodCore::InvalidCluster)
+        end
+      end
+
+      it "correctly populates id and metadata" do
+        clusters = OodCore::Clusters.load_file(config)
+        clusters.each do |cluster|
+          id = cluster.id.to_s
+          error_msg = cluster.metadata.error_msg.to_s
+
+          expect(id).to eql('malformed')
+          expect(error_msg).not_to be_empty
+        end
+      end
+    end
+
   end
 end

--- a/spec/fixtures/config/clusters.d/malformed.yml
+++ b/spec/fixtures/config/clusters.d/malformed.yml
@@ -1,0 +1,14 @@
+---
+v2:
+  metadata:
+    title "Owens"
+    url: "https://www.osc.edu/supercomputing/computing/owens"
+    hidden: false
+  login:
+    host: "owens.osc.edu"
+  job:
+    adapter: "torque"
+    host: "owens-batch.ten.osc.edu"
+    lib: "/opt/torque/lib64"
+    bin: "/opt/torque/bin"
+    version: "6.0.1"


### PR DESCRIPTION
This can catch Psych::SyntaxError while parsing a malformed cluster definition file and safely traverse empty cluster definitions.  This tries to fix #150 and #178. 

Most uses of Clusters filter off of `allow?` or `custom_allow?` and the InvalidCluster doesn't allow for anything so most (if not all) uses of clusters will filter these types out. 

Right now the only things you can really rely on are the `id` and `metadata.error_msg`. 