### PR TITLE
info_where_owner signature is wrong. owner is not a named parameter

### DIFF
--- a/lib/ood_core/job/adapters/linux_host.rb
+++ b/lib/ood_core/job/adapters/linux_host.rb
@@ -106,7 +106,7 @@ module OodCore
         # @param owner [#to_s, Array<#to_s>] the owner(s) of the jobs
         # @raise [JobAdapterError] if something goes wrong getting job info
         # @return [Array<Info>] information describing submitted jobs
-        def info_where_owner(owner: nil, attrs: nil)
+        def info_where_owner(_, attrs: nil)
           info_all
         end
 

--- a/spec/job/adapters/linux_host_spec.rb
+++ b/spec/job/adapters/linux_host_spec.rb
@@ -127,7 +127,7 @@ describe OodCore::Job::Adapters::LinuxHost do
     it "implements the Adapter interface" do
         is_expected.to respond_to(:submit).with(1).argument.and_keywords(:after, :afterok, :afternotok, :afterany)
         is_expected.to respond_to(:info_all).with(0).arguments.and_keywords(:attrs)
-        is_expected.to respond_to(:info_where_owner).with(0).arguments.and_keywords(:owner, :attrs)
+        is_expected.to respond_to(:info_where_owner).with(1).arguments.and_keywords(:attrs)
         is_expected.to respond_to(:info).with(1).argument
         is_expected.to respond_to(:status).with(1).argument
         is_expected.to respond_to(:hold).with(1).argument


### PR DESCRIPTION
Active Jobs throws this error.  I tracked it down to the LHA's info_where_owner signature being just a little off. 

![image](https://user-images.githubusercontent.com/4874123/80150680-c8407200-8586-11ea-95e3-d7d616200fd4.png)
