### PR TITLE
Attributes from qstat command now found under native hash

### DIFF
--- a/lib/ood_core/job/adapters/sge/qstat_xml_j_r_listener.rb
+++ b/lib/ood_core/job/adapters/sge/qstat_xml_j_r_listener.rb
@@ -28,10 +28,13 @@ class QstatXmlJRListener
       :tasks => [],
       :status => :queued,
       :procs => 1,
-      :native => {}  # TODO: improve native attribute reporting
+      :native => {
+        :ST_name = ''
+      }  # TODO: improve native attribute reporting
     }
     @current_text = nil
     @current_request = nil
+    @stdout_PN_path = false
 
     @processing_job_array_spec = false
     @adding_slots = false
@@ -42,6 +45,7 @@ class QstatXmlJRListener
       step: 1,  # Step can have a default of 1
     }
     @running_tasks = []
+    @native_tags = ['JB_job_number', 'JB_job_name', 'JB_version', 'JB_project', 'JB_exec_file', 'JB_script_file', 'JB_script_size', 'JB_submission_time', 'JB_execution_time', 'JB_deadline', 'JB_owner', 'JB_uid', 'JB_group', 'JB_gid', 'JB_account', 'JB_cwd', 'JB_notify', 'JB_type', 'JB_reserve', 'JB_priority', 'JB_jobshare', 'JB_verify', 'JB_checkpoint_attr', 'JB_checkpoint_interval', 'JB_restart']
   end
 
   def tag_start(name, attrs)
@@ -50,13 +54,15 @@ class QstatXmlJRListener
       toggle_processing_array_spec
     when 'JB_pe_range'
       toggle_adding_slots
+    when 'JB_stdout_path_list'
+      @stdout_PN_path = true
     end
   end
 
   def tag_end(name)
-    #Add this to native hash if there is a text node
-    if (!@current_text.strip.empty?)
-      @current_job[:native][name] = @current_text
+    #Add to native hash if in native_tags
+    if (@native_tags.include?(name))
+      @current_job[:native][:"#{name}"] = @current_text
     end
 
     case name
@@ -97,6 +103,10 @@ class QstatXmlJRListener
       toggle_processing_array_spec
     when 'JB_pe_range'
       toggle_adding_slots
+    when 'PN_path' 
+      end_PN_path
+    when 'ST_name'
+      end_ST_name
     end
   end
 
@@ -176,6 +186,17 @@ class QstatXmlJRListener
   # Used to record a running Job Array task
   def end_JAT_task_number
     @running_tasks << @current_text
+  end
+
+  def end_PN_path
+    if (@stdout_PN_path)
+      @stdout_PN_path = false
+      @current_job[:native][:PN_path] = @current_text
+    end
+  end
+
+  def end_ST_name
+    @parsed_job[:native][:ST_name] = @parsed_job[:native][:ST_name] + @current_text + ' '
   end
 
   def set_job_array_piece(key)

--- a/lib/ood_core/job/adapters/sge/qstat_xml_j_r_listener.rb
+++ b/lib/ood_core/job/adapters/sge/qstat_xml_j_r_listener.rb
@@ -54,6 +54,11 @@ class QstatXmlJRListener
   end
 
   def tag_end(name)
+    #Add this to native hash if there is a text node
+    if (!@current_text.strip.empty?)
+      @current_job[:native][name] = @current_text
+    end
+
     case name
     when 'JB_ja_tasks'
       end_JB_ja_tasks
@@ -92,10 +97,6 @@ class QstatXmlJRListener
       toggle_processing_array_spec
     when 'JB_pe_range'
       toggle_adding_slots
-    when 'cpu_usage'
-      end_cpu_usage
-    when 'mem_usage'
-      end_mem_usage
     end
   end
 
@@ -106,34 +107,39 @@ class QstatXmlJRListener
 
   # Attributes we need
   def end_JB_job_number
-    @parsed_job[:native][:id] = @current_text
+    @parsed_job[:id] = @current_text
   end
 
   def end_JB_owner
-    @parsed_job[:native][:job_owner] = @current_text
+    @parsed_job[:job_owner] = @current_text
   end
 
   def end_JB_project
-    @parsed_job[:native][:accounting_id] = @current_text
+    @parsed_job[:accounting_id] = @current_text
   end
 
   def end_JB_job_name
-    @parsed_job[:native][:job_name] = @current_text
+    @parsed_job[:job_name] = @current_text
   end
 
   def end_JB_submission_time
+<<<<<<< HEAD
 <<<<<<< HEAD
     @parsed_job[:submission_time] = ms_to_seconds(@current_text.to_i)
 =======
     @parsed_job[:native][:submission_time] = @current_text.to_i
 >>>>>>> Attributes from qstat command now found under native hash
+=======
+    @parsed_job[:submission_time] = @current_text.to_i
+>>>>>>> Saves params under current job and saves all values under current_text[:native]
   end
 
   def end_JB_ja_tasks
-    @parsed_job[:native][:status] = :running
+    @parsed_job[:status] = :running
   end
 
   def end_JAT_start_time
+<<<<<<< HEAD
 <<<<<<< HEAD
     @parsed_job[:status] = :running
     @parsed_job[:dispatch_time] = ms_to_seconds(@current_text.to_i)
@@ -143,6 +149,11 @@ class QstatXmlJRListener
     @parsed_job[:native][:dispatch_time] = @current_text.to_i
     @parsed_job[:native][:wallclock_time] = Time.now.to_i - @parsed_job[:native][:dispatch_time]
 >>>>>>> Attributes from qstat command now found under native hash
+=======
+    @parsed_job[:status] = :running
+    @parsed_job[:dispatch_time] = @current_text.to_i
+    @parsed_job[:wallclock_time] = Time.now.to_i - @parsed_job[:dispatch_time]
+>>>>>>> Saves params under current job and saves all values under current_text[:native]
   end
 
   def end_CE_name
@@ -154,12 +165,12 @@ class QstatXmlJRListener
 
     case @current_request
     when 'h_rt'  # hard run time limit
-      @parsed_job[:native][:wallclock_limit] = @current_text.to_i
+      @parsed_job[:wallclock_limit] = @current_text.to_i
     end
   end
 
   def end_QR_name
-    @parsed_job[:native][:queue_name] = @current_text
+    @parsed_job[:queue_name] = @current_text
   end
 
   # Used to record a running Job Array task
@@ -169,14 +180,6 @@ class QstatXmlJRListener
 
   def set_job_array_piece(key)
     @job_array_spec[key] = @current_text if @processing_job_array_spec
-  end
-
-  def end_cpu_usage
-    @current_job[:native][:cpu_usage] = @current_text
-  end
-
-  def end_mem_usage
-    @current_job[:native][:mem_usage] = @current_text
   end
 
   def spec_string
@@ -221,7 +224,7 @@ class QstatXmlJRListener
   end
 
   def set_slots
-    @parsed_job[:native][:procs] = @current_text.to_i
+    @parsed_job[:procs] = @current_text.to_i
   end
 
   private

--- a/lib/ood_core/job/adapters/sge/qstat_xml_j_r_listener.rb
+++ b/lib/ood_core/job/adapters/sge/qstat_xml_j_r_listener.rb
@@ -30,7 +30,7 @@ class QstatXmlJRListener
       :procs => 1,
       :native => {
         :ST_name => ''
-      }  # TODO: improve native attribute reporting
+      } 
     }
     @current_text = nil
     @current_request = nil
@@ -133,15 +133,7 @@ class QstatXmlJRListener
   end
 
   def end_JB_submission_time
-<<<<<<< HEAD
-<<<<<<< HEAD
     @parsed_job[:submission_time] = ms_to_seconds(@current_text.to_i)
-=======
-    @parsed_job[:native][:submission_time] = @current_text.to_i
->>>>>>> Attributes from qstat command now found under native hash
-=======
-    @parsed_job[:submission_time] = @current_text.to_i
->>>>>>> Saves params under current job and saves all values under current_text[:native]
   end
 
   def end_JB_ja_tasks
@@ -149,21 +141,9 @@ class QstatXmlJRListener
   end
 
   def end_JAT_start_time
-<<<<<<< HEAD
-<<<<<<< HEAD
     @parsed_job[:status] = :running
     @parsed_job[:dispatch_time] = ms_to_seconds(@current_text.to_i)
     @parsed_job[:wallclock_time] = Time.now.to_i - @parsed_job[:dispatch_time]
-=======
-    @parsed_job[:native][:status] = :running
-    @parsed_job[:native][:dispatch_time] = @current_text.to_i
-    @parsed_job[:native][:wallclock_time] = Time.now.to_i - @parsed_job[:native][:dispatch_time]
->>>>>>> Attributes from qstat command now found under native hash
-=======
-    @parsed_job[:status] = :running
-    @parsed_job[:dispatch_time] = @current_text.to_i
-    @parsed_job[:wallclock_time] = Time.now.to_i - @parsed_job[:dispatch_time]
->>>>>>> Saves params under current job and saves all values under current_text[:native]
   end
 
   def end_CE_name

--- a/lib/ood_core/job/adapters/sge/qstat_xml_j_r_listener.rb
+++ b/lib/ood_core/job/adapters/sge/qstat_xml_j_r_listener.rb
@@ -29,7 +29,7 @@ class QstatXmlJRListener
       :status => :queued,
       :procs => 1,
       :native => {
-        :ST_name = ''
+        :ST_name => ''
       }  # TODO: improve native attribute reporting
     }
     @current_text = nil
@@ -62,7 +62,7 @@ class QstatXmlJRListener
   def tag_end(name)
     #Add to native hash if in native_tags
     if (@native_tags.include?(name))
-      @current_job[:native][:"#{name}"] = @current_text
+      @parsed_job[:native][:"#{name}"] = @current_text
     end
 
     case name
@@ -191,7 +191,7 @@ class QstatXmlJRListener
   def end_PN_path
     if (@stdout_PN_path)
       @stdout_PN_path = false
-      @current_job[:native][:PN_path] = @current_text
+      @parsed_job[:native][:PN_path] = @current_text
     end
   end
 

--- a/lib/ood_core/job/adapters/sge/qstat_xml_j_r_listener.rb
+++ b/lib/ood_core/job/adapters/sge/qstat_xml_j_r_listener.rb
@@ -34,7 +34,7 @@ class QstatXmlJRListener
     }
     @current_text = nil
     @current_request = nil
-    @stdout_PN_path = false
+    @processing_JB_stdout_path_list = false
 
     @processing_job_array_spec = false
     @adding_slots = false
@@ -55,7 +55,7 @@ class QstatXmlJRListener
     when 'JB_pe_range'
       toggle_adding_slots
     when 'JB_stdout_path_list'
-      @stdout_PN_path = true
+      @processing_JB_stdout_path_list = true
     end
   end
 
@@ -189,10 +189,8 @@ class QstatXmlJRListener
   end
 
   def end_PN_path
-    if (@stdout_PN_path)
-      @stdout_PN_path = false
-      @parsed_job[:native][:PN_path] = @current_text
-    end
+    @parsed_job[:native][:PN_path] = @current_text if @processing_JB_stdout_path_list
+    @processing_JB_stdout_path_list = false
   end
 
   def end_ST_name

--- a/lib/ood_core/job/adapters/sge/qstat_xml_j_r_listener.rb
+++ b/lib/ood_core/job/adapters/sge/qstat_xml_j_r_listener.rb
@@ -92,6 +92,10 @@ class QstatXmlJRListener
       toggle_processing_array_spec
     when 'JB_pe_range'
       toggle_adding_slots
+    when 'cpu_usage'
+      end_cpu_usage
+    when 'mem_usage'
+      end_mem_usage
     end
   end
 
@@ -102,33 +106,43 @@ class QstatXmlJRListener
 
   # Attributes we need
   def end_JB_job_number
-    @parsed_job[:id] = @current_text
+    @parsed_job[:native][:id] = @current_text
   end
 
   def end_JB_owner
-    @parsed_job[:job_owner] = @current_text
+    @parsed_job[:native][:job_owner] = @current_text
   end
 
   def end_JB_project
-    @parsed_job[:accounting_id] = @current_text
+    @parsed_job[:native][:accounting_id] = @current_text
   end
 
   def end_JB_job_name
-    @parsed_job[:job_name] = @current_text
+    @parsed_job[:native][:job_name] = @current_text
   end
 
   def end_JB_submission_time
+<<<<<<< HEAD
     @parsed_job[:submission_time] = ms_to_seconds(@current_text.to_i)
+=======
+    @parsed_job[:native][:submission_time] = @current_text.to_i
+>>>>>>> Attributes from qstat command now found under native hash
   end
 
   def end_JB_ja_tasks
-    @parsed_job[:status] = :running
+    @parsed_job[:native][:status] = :running
   end
 
   def end_JAT_start_time
+<<<<<<< HEAD
     @parsed_job[:status] = :running
     @parsed_job[:dispatch_time] = ms_to_seconds(@current_text.to_i)
     @parsed_job[:wallclock_time] = Time.now.to_i - @parsed_job[:dispatch_time]
+=======
+    @parsed_job[:native][:status] = :running
+    @parsed_job[:native][:dispatch_time] = @current_text.to_i
+    @parsed_job[:native][:wallclock_time] = Time.now.to_i - @parsed_job[:native][:dispatch_time]
+>>>>>>> Attributes from qstat command now found under native hash
   end
 
   def end_CE_name
@@ -140,12 +154,12 @@ class QstatXmlJRListener
 
     case @current_request
     when 'h_rt'  # hard run time limit
-      @parsed_job[:wallclock_limit] = @current_text.to_i
+      @parsed_job[:native][:wallclock_limit] = @current_text.to_i
     end
   end
 
   def end_QR_name
-    @parsed_job[:queue_name] = @current_text
+    @parsed_job[:native][:queue_name] = @current_text
   end
 
   # Used to record a running Job Array task
@@ -155,6 +169,14 @@ class QstatXmlJRListener
 
   def set_job_array_piece(key)
     @job_array_spec[key] = @current_text if @processing_job_array_spec
+  end
+
+  def end_cpu_usage
+    @current_job[:native][:cpu_usage] = @current_text
+  end
+
+  def end_mem_usage
+    @current_job[:native][:mem_usage] = @current_text
   end
 
   def spec_string
@@ -199,7 +221,7 @@ class QstatXmlJRListener
   end
 
   def set_slots
-    @parsed_job[:procs] = @current_text.to_i
+    @parsed_job[:native][:procs] = @current_text.to_i
   end
 
   private

--- a/lib/ood_core/job/adapters/sge/qstat_xml_r_listener.rb
+++ b/lib/ood_core/job/adapters/sge/qstat_xml_r_listener.rb
@@ -26,7 +26,7 @@ class QstatXmlRListener
       :tasks => [],
       :native => {
         :ST_name => ''
-      }  # TODO: improve native reporting
+      } 
     }
     @current_text = nil
     @processing_JB_stdout_path_list = false

--- a/lib/ood_core/job/adapters/sge/qstat_xml_r_listener.rb
+++ b/lib/ood_core/job/adapters/sge/qstat_xml_r_listener.rb
@@ -25,7 +25,7 @@ class QstatXmlRListener
     @current_job = {
       :tasks => [],
       :native => {
-        :ST_name = ''
+        :ST_name => ''
       }  # TODO: improve native reporting
     }
     @current_text = nil
@@ -74,7 +74,7 @@ class QstatXmlRListener
     when 'hard_request'
       end_hard_request
     when 'tasks'
-      end_child_tasks
+      add_child_tasks
     when 'PN_path'
       end_PN_path
     when 'ST_name'
@@ -153,7 +153,7 @@ class QstatXmlRListener
   end
 
   def end_ST_name
-    @parsed_job[:native][:ST_name] = @parsed_job[:native][:ST_name] + @current_text + ' '
+    @current_job[:native][:ST_name] = @current_job[:native][:ST_name] + @current_text + ' '
   end
 
   # Store a completed job and reset current_job for the next pass

--- a/lib/ood_core/job/adapters/sge/qstat_xml_r_listener.rb
+++ b/lib/ood_core/job/adapters/sge/qstat_xml_r_listener.rb
@@ -63,7 +63,11 @@ class QstatXmlRListener
     when 'hard_request'
       end_hard_request
     when 'tasks'
-      add_child_tasks
+      end_child_tasks
+    when 'cpu_usage'
+      end_cpu_usage
+    when 'mem_usage'
+      end_mem_usage
     end
   end
 
@@ -85,40 +89,40 @@ class QstatXmlRListener
 
   # Attributes we need
   def end_JB_job_number
-    @current_job[:id] = @current_text
+    @current_job[:native][:id] = @current_text
   end
 
   def end_JB_owner
-    @current_job[:job_owner] = @current_text
+    @current_job[:native][:job_owner] = @current_text
   end
 
   def end_JB_project
-    @current_job[:accounting_id] = @current_text
+    @current_job[:native][:accounting_id] = @current_text
   end
 
   def end_JB_name
-    @current_job[:job_name] = @current_text
+    @current_job[:native][:job_name] = @current_text
   end
 
   # Note that this is the native SGE type
   def end_state
-    @current_job[:status] = @current_text
+    @current_job[:native][:status] = @current_text
   end
 
   def end_slots
-    @current_job[:procs] = @current_text.to_i
+    @current_job[:native][:procs] = @current_text.to_i
   end
 
   def end_hard_req_queue
-    @current_job[:queue_name] = @current_text
+    @current_job[:native][:queue_name] = @current_text
   end
 
   def end_JB_submission_time
-    @current_job[:submission_time] = DateTime.parse(@current_text).to_time.to_i
+    @current_job[:native][:submission_time] = DateTime.parse(@current_text).to_time.to_i
   end
 
   def end_JAT_start_time
-    @current_job[:dispatch_time] = DateTime.parse(@current_text).to_time.to_i
+    @current_job[:native][:dispatch_time] = DateTime.parse(@current_text).to_time.to_i
   end
 
   def end_hard_request
@@ -126,8 +130,16 @@ class QstatXmlRListener
 
     case @current_request
     when 'h_rt'  # hard run time limit
-      @current_job[:wallclock_limit] = @current_text.to_i
+      @current_job[:native][:wallclock_limit] = @current_text.to_i
     end
+  end
+  
+  def end_cpu_usage
+    @current_job[:native][:cpu_usage] = @current_text
+  end
+
+  def end_mem_usage
+    @current_job[:native][:mem_usage] = @current_text
   end
 
   # Store a completed job and reset current_job for the next pass
@@ -145,4 +157,3 @@ class QstatXmlRListener
     }
   end
 end
-

--- a/lib/ood_core/job/adapters/sge/qstat_xml_r_listener.rb
+++ b/lib/ood_core/job/adapters/sge/qstat_xml_r_listener.rb
@@ -39,6 +39,11 @@ class QstatXmlRListener
   end
 
   def tag_end(name)
+    #Add this to native hash if there is a text node
+    if (!@current_text.strip.empty?)
+      @current_job[:native][name] = @current_text
+    end
+    
     case name
     when 'job_list'
       end_job_list
@@ -64,10 +69,6 @@ class QstatXmlRListener
       end_hard_request
     when 'tasks'
       end_child_tasks
-    when 'cpu_usage'
-      end_cpu_usage
-    when 'mem_usage'
-      end_mem_usage
     end
   end
 
@@ -89,40 +90,40 @@ class QstatXmlRListener
 
   # Attributes we need
   def end_JB_job_number
-    @current_job[:native][:id] = @current_text
+    @current_job[:id] = @current_text
   end
 
   def end_JB_owner
-    @current_job[:native][:job_owner] = @current_text
+    @current_job[:job_owner] = @current_text
   end
 
   def end_JB_project
-    @current_job[:native][:accounting_id] = @current_text
+    @current_job[:accounting_id] = @current_text
   end
 
   def end_JB_name
-    @current_job[:native][:job_name] = @current_text
+    @current_job[:job_name] = @current_text
   end
 
   # Note that this is the native SGE type
   def end_state
-    @current_job[:native][:status] = @current_text
+    @current_job[:status] = @current_text
   end
 
   def end_slots
-    @current_job[:native][:procs] = @current_text.to_i
+    @current_job[:procs] = @current_text.to_i
   end
 
   def end_hard_req_queue
-    @current_job[:native][:queue_name] = @current_text
+    @current_job[:queue_name] = @current_text
   end
 
   def end_JB_submission_time
-    @current_job[:native][:submission_time] = DateTime.parse(@current_text).to_time.to_i
+    @current_job[:submission_time] = DateTime.parse(@current_text).to_time.to_i
   end
 
   def end_JAT_start_time
-    @current_job[:native][:dispatch_time] = DateTime.parse(@current_text).to_time.to_i
+    @current_job[:dispatch_time] = DateTime.parse(@current_text).to_time.to_i
   end
 
   def end_hard_request
@@ -130,16 +131,8 @@ class QstatXmlRListener
 
     case @current_request
     when 'h_rt'  # hard run time limit
-      @current_job[:native][:wallclock_limit] = @current_text.to_i
+      @current_job[:wallclock_limit] = @current_text.to_i
     end
-  end
-  
-  def end_cpu_usage
-    @current_job[:native][:cpu_usage] = @current_text
-  end
-
-  def end_mem_usage
-    @current_job[:native][:mem_usage] = @current_text
   end
 
   # Store a completed job and reset current_job for the next pass

--- a/lib/ood_core/job/adapters/sge/qstat_xml_r_listener.rb
+++ b/lib/ood_core/job/adapters/sge/qstat_xml_r_listener.rb
@@ -29,7 +29,7 @@ class QstatXmlRListener
       }  # TODO: improve native reporting
     }
     @current_text = nil
-    @stdout_PN_path = false
+    @processing_JB_stdout_path_list = false
 
     @current_request = nil
     @native_tags = ['JB_job_number', 'JB_job_name', 'JB_version', 'JB_project', 'JB_exec_file', 'JB_script_file', 'JB_script_size', 'JB_submission_time', 'JB_execution_time', 'JB_deadline', 'JB_owner', 'JB_uid', 'JB_group', 'JB_gid', 'JB_account', 'JB_cwd', 'JB_notify', 'JB_type', 'JB_reserve', 'JB_priority', 'JB_jobshare', 'JB_verify', 'JB_checkpoint_attr', 'JB_checkpoint_interval', 'JB_restart']
@@ -40,7 +40,7 @@ class QstatXmlRListener
     when 'hard_request'
       start_hard_request(attributes)
     when "JB_stdout_path_list"
-      @stdout_PN_path = true
+      @processing_JB_stdout_path_list = true
     end
   end
 
@@ -146,10 +146,8 @@ class QstatXmlRListener
   end
 
   def end_PN_path
-    if (@stdout_PN_path)
-      @stdout_PN_path = false
-      @current_job[:native][:PN_path] = @current_text
-    end
+    @current_job[:native][:PN_path] = @current_text if @processing_JB_stdout_path_list
+    @processing_JB_stdout_path_list = false
   end
 
   def end_ST_name

--- a/lib/ood_core/job/adapters/sge/qstat_xml_r_listener.rb
+++ b/lib/ood_core/job/adapters/sge/qstat_xml_r_listener.rb
@@ -24,24 +24,30 @@ class QstatXmlRListener
     @parsed_jobs = []
     @current_job = {
       :tasks => [],
-      :native => {}  # TODO: improve native reporting
+      :native => {
+        :ST_name = ''
+      }  # TODO: improve native reporting
     }
     @current_text = nil
+    @stdout_PN_path = false
 
     @current_request = nil
+    @native_tags = ['JB_job_number', 'JB_job_name', 'JB_version', 'JB_project', 'JB_exec_file', 'JB_script_file', 'JB_script_size', 'JB_submission_time', 'JB_execution_time', 'JB_deadline', 'JB_owner', 'JB_uid', 'JB_group', 'JB_gid', 'JB_account', 'JB_cwd', 'JB_notify', 'JB_type', 'JB_reserve', 'JB_priority', 'JB_jobshare', 'JB_verify', 'JB_checkpoint_attr', 'JB_checkpoint_interval', 'JB_restart']
   end
 
   def tag_start(name, attributes)
     case name
     when 'hard_request'
       start_hard_request(attributes)
+    when "JB_stdout_path_list"
+      @stdout_PN_path = true
     end
   end
 
   def tag_end(name)
-    #Add this to native hash if there is a text node
-    if (!@current_text.strip.empty?)
-      @current_job[:native][name] = @current_text
+    #Add text if in native_tags
+    if (@native_tags.include?(name))
+      @current_job[:native][:"#{name}"] = @current_text
     end
     
     case name
@@ -69,6 +75,10 @@ class QstatXmlRListener
       end_hard_request
     when 'tasks'
       end_child_tasks
+    when 'PN_path'
+      end_PN_path
+    when 'ST_name'
+      end_ST_name
     end
   end
 
@@ -133,6 +143,17 @@ class QstatXmlRListener
     when 'h_rt'  # hard run time limit
       @current_job[:wallclock_limit] = @current_text.to_i
     end
+  end
+
+  def end_PN_path
+    if (@stdout_PN_path)
+      @stdout_PN_path = false
+      @current_job[:native][:PN_path] = @current_text
+    end
+  end
+
+  def end_ST_name
+    @parsed_job[:native][:ST_name] = @parsed_job[:native][:ST_name] + @current_text + ' '
   end
 
   # Store a completed job and reset current_job for the next pass

--- a/spec/job/adapters/sge/batch_spec.rb
+++ b/spec/job/adapters/sge/batch_spec.rb
@@ -20,7 +20,12 @@ describe OodCore::Job::Adapters::Sge::Batch do
       :dispatch_time => DateTime.parse('2018-10-10T14:37:16').to_time.to_i,
       :wallclock_limit => 360,
       :wallclock_time => Time.now.to_i - DateTime.parse('2018-10-10T14:37:16').to_time.to_i,
-      :native => {}
+      :native => {
+        :ST_name=>"", 
+        :JB_job_number=>"88", 
+        :JB_owner=>"vagrant", 
+        :JB_project=>"project_a"
+      }
     ),
     OodCore::Job::Info.new( # Queued job, w/ project
       :id => '1045',
@@ -33,7 +38,12 @@ describe OodCore::Job::Adapters::Sge::Batch do
       :submission_time => DateTime.parse('2018-10-09T18:47:05').to_time.to_i,
       :wallclock_limit => 360,
       :wallclock_time => 0,
-      :native => {}
+      :native => {
+        :JB_job_number=>"1045", 
+        :JB_owner=>"vagrant", 
+        :JB_project=>"project_b", 
+        :JB_submission_time=>"2018-10-09T18:47:05"
+      }
     ),
     OodCore::Job::Info.new( # Queued job w/o project
       :id => '1046',
@@ -45,7 +55,11 @@ describe OodCore::Job::Adapters::Sge::Batch do
       :submission_time => DateTime.parse('2018-10-09T18:47:05').to_time.to_i,
       :wallclock_limit => 360,
       :wallclock_time => 0,
-      :native => {},
+      :native => {
+        :JB_job_number=>"1046", 
+        :JB_owner=>"vagrant", 
+        :JB_submission_time=>"2018-10-09T18:47:05"
+      },
       :tasks => [
         { :id => '1', :status => :queued },
         { :id => '3', :status => :queued },
@@ -64,7 +78,11 @@ describe OodCore::Job::Adapters::Sge::Batch do
       :submission_time => DateTime.parse('2018-10-09T18:35:12').to_time.to_i,
       :wallclock_limit => 360,
       :wallclock_time => 0,
-      :native => {}
+      :native => {
+        :JB_job_number=>"44", 
+        :JB_owner=>"vagrant", 
+        :JB_submission_time=>"2018-10-09T18:35:12"
+      }
     )
   ]}
 
@@ -77,7 +95,34 @@ describe OodCore::Job::Adapters::Sge::Batch do
       :id => "4147342",
       :job_name => "cfSNV_0merged_split_pileup_241.FLASH.recal_10.pbs",
       :job_owner => "shuoli",
-      :native => {},
+      :native =>{
+        :ST_name=>"",
+        :JB_job_number=>"4147342",
+        :JB_exec_file=>"job_scripts/4147342",
+        :JB_submission_time=>"1541444183",
+        :JB_owner=>"shuoli",
+        :JB_uid=>"13287",
+        :JB_group=>"xjzhou",
+        :JB_gid=>"12426",
+        :JB_account=>"sge",
+        :JB_project=>"xjzhou_prj",
+        :JB_notify=>"false",
+        :JB_job_name=>"cfSNV_0merged_split_pileup_241.FLASH.recal_10.pbs",
+        :JB_jobshare=>"0",
+        :JB_script_file=>"cfSNV_0merged_split_pileup_241.FLASH.recal_10.pbs",
+        :JB_cwd=>"/u/project/xjzhou/shuoli/Zo_WES_plasma_SC1810033_10312018/code/0",
+        :JB_deadline=>"0",
+        :JB_execution_time=>"0",
+        :JB_checkpoint_attr=>"0",
+        :JB_checkpoint_interval=>"0",
+        :JB_reserve=>"false",
+        :JB_priority=>"1024",
+        :JB_restart=>"0",
+        :JB_verify=>"0",
+        :JB_script_size=>"0",
+        :JB_version=>"0",
+        :JB_type=>"0"
+      },
       :procs => 1,
       :queue_name => nil,
       :status => :running,
@@ -97,7 +142,34 @@ describe OodCore::Job::Adapters::Sge::Batch do
       :id => "942195",
       :job_name => "RemoteDesktop",
       :job_owner => "smatott",
-      :native => {},
+      :native => {
+        :ST_name=>"",
+        :JB_job_number=>"942195",
+        :JB_exec_file=>"job_scripts/942195",
+        :JB_submission_time=>"1576525304",
+        :JB_owner=>"smatott",
+        :JB_uid=>"1105",
+        :JB_group=>"packages",
+        :JB_gid=>"3002",
+        :JB_account=>"sge",
+        :JB_notify=>"false",
+        :JB_job_name=>"RemoteDesktop",
+        :PN_path=> "/mnt/lustre/users/smatott/ondemand/data/sys/dashboard/batch_connect/sys/bc_desktop/hpc/output/9beca517-07fa-4379-8eb7-934460846a19/output.log",
+        :JB_jobshare=>"0",
+        :JB_script_file=>"STDIN",
+        :JB_cwd=> "/mnt/lustre/users/smatott/ondemand/data/sys/dashboard/batch_connect/sys/bc_desktop/hpc/output/9beca517-07fa-4379-8eb7-934460846a19",
+        :JB_deadline=>"0",
+        :JB_execution_time=>"0",
+        :JB_checkpoint_attr=>"0",
+        :JB_checkpoint_interval=>"0",
+        :JB_reserve=>"false",
+        :JB_priority=>"1024",
+        :JB_restart=>"0",
+        :JB_verify=>"0",
+        :JB_script_size=>"0",
+        :JB_version=>"0",
+        :JB_type=>"0"
+      },
       :procs => 16,
       :queue_name => 'all.q',
       :status => :running,

--- a/spec/job/adapters/sge/batch_spec.rb
+++ b/spec/job/adapters/sge/batch_spec.rb
@@ -189,7 +189,35 @@ describe OodCore::Job::Adapters::Sge::Batch do
       :id => "748172",
       :job_name => "jupyter_interactive",
       :job_owner => "johrstrom",
-      :native => {},
+      :native => {
+        :ST_name=>"/export/uge/bin/lx-amd64/qsub -wd /home/johrstrom/ondemand/data/sys/dashboard/batch_connect/sys/jupyter/output/a4a46499-77d9-4334-bef2-71dd0a0857f6 -N jupyter_interactive -o /home/johrstrom/ondemand/data/sys/dashboard/batch_connect/sys/jupyter/output/a4a46499-77d9-4334-bef2-71dd0a0857f6/output.log -q ondemand -l h_rt=04:00:00 -P communitycluster -V -pe sm 11 hpcc ",
+        :JB_job_number=>"748172",
+        :JB_job_name=>"jupyter_interactive",
+        :JB_version=>"0",
+        :JB_project=>"communitycluster",
+        :JB_exec_file=>"job_scripts/748172",
+        :JB_script_file=>"STDIN",
+        :JB_script_size=>"0",
+        :JB_submission_time=>"1592928409331",
+        :JB_execution_time=>"0",
+        :JB_deadline=>"0",
+        :JB_owner=>"johrstrom",
+        :JB_uid=>"99577",
+        :JB_group=>"hpcc",
+        :JB_gid=>"101",
+        :JB_account=>"sge",
+        :JB_cwd=>"/home/johrstrom/ondemand/data/sys/dashboard/batch_connect/sys/jupyter/output/a4a46499-77d9-4334-bef2-71dd0a0857f6",
+        :JB_notify=>"false",
+        :JB_type=>"0",
+        :JB_reserve=>"false",
+        :JB_priority=>"0",
+        :JB_jobshare=>"0",
+        :JB_verify=>"0",
+        :JB_checkpoint_attr=>"0",
+        :JB_checkpoint_interval=>"0",
+        :JB_restart=>"0",
+        :PN_path=>"/home/johrstrom/ondemand/data/sys/dashboard/batch_connect/sys/jupyter/output/a4a46499-77d9-4334-bef2-71dd0a0857f6/output.log"
+      },
       :procs => 11,
       :queue_name => 'ondemand',
       :status => :running,
@@ -281,6 +309,10 @@ describe OodCore::Job::Adapters::Sge::Batch do
 
       it "expects to receive the correct job info" do
         expect(batch.get_info_enqueued_job('748172') ).to eq(job_from_uge_qstat_jr)
+      end
+
+      it "expects to receive the correct ST_name" do 
+        expect(batch.get_info_enqueued_job('748172').native[:ST_name] ).to eq("/export/uge/bin/lx-amd64/qsub -wd /home/johrstrom/ondemand/data/sys/dashboard/batch_connect/sys/jupyter/output/a4a46499-77d9-4334-bef2-71dd0a0857f6 -N jupyter_interactive -o /home/johrstrom/ondemand/data/sys/dashboard/batch_connect/sys/jupyter/output/a4a46499-77d9-4334-bef2-71dd0a0857f6/output.log -q ondemand -l h_rt=04:00:00 -P communitycluster -V -pe sm 11 hpcc ")
       end
     end
   end


### PR DESCRIPTION
Added cpu/mem_usage attributes following gridengine/qstat.xsd