### PR TITLE
checks for similarity between ssh_host and hostname -A

### DIFF
--- a/lib/ood_core/job/adapters/linux_host/launcher.rb
+++ b/lib/ood_core/job/adapters/linux_host/launcher.rb
@@ -64,12 +64,8 @@ class OodCore::Job::Adapters::LinuxHost::Launcher
     hostnames = output.strip.split #Will capture all other data too
     ssh_host_array = @ssh_hosts.to_a #is a Set seen in linux_host.rb
     hostname = (hostnames & ssh_host_array).first
+    raise Error, "The specified host is not in the list of ssh hosts configured for this cluster. The ssh hosts configured are #{ssh_host_array.inspect}. The specified host for this job is determined by running 'hostname -A' on the target host and this output must match one of the specified ssh hosts" unless !hostname.nil?
 
-    if (hostname.nil?)
-      Error => e 
-      raise e unless e.message.include?("The specified host is not in the list of ssh hosts configured for this cluster. The ssh hosts configured are #{ssh_host_array.inspect}. The specified host for this job is determined by running 'hostname -A' on the target host and this output must match one of the specified ssh hosts")
-    end
-    
     "#{session_name}@#{hostname}"
   end
 

--- a/lib/ood_core/job/adapters/linux_host/launcher.rb
+++ b/lib/ood_core/job/adapters/linux_host/launcher.rb
@@ -61,8 +61,15 @@ class OodCore::Job::Adapters::LinuxHost::Launcher
 
     session_name = unique_session_name
     output = call(*cmd, stdin: wrapped_script(script, session_name))
-    hostname = output.strip
+    hostnames = output.strip.split #Will capture all other data too
+    ssh_host_array = @ssh_hosts.to_a #is a Set seen in linux_host.rb
+    hostname = (hostnames & ssh_host_array).first
 
+    if (hostname.nil?)
+      Error => e 
+      raise e unless e.message.include?("The specified host is not in the list of ssh hosts configured for this cluster. The ssh hosts configured are #{ssh_host_array.inspect}. The specified host for this job is determined by running 'hostname -A' on the target host and this output must match one of the specified ssh hosts")
+    end
+    
     "#{session_name}@#{hostname}"
   end
 

--- a/lib/ood_core/job/adapters/linux_host/templates/script_wrapper.erb.sh
+++ b/lib/ood_core/job/adapters/linux_host/templates/script_wrapper.erb.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-hostname
+hostname -A
 
 # Put the script into a temp file on localhost
 <% if debug %>


### PR DESCRIPTION
Not sure if this is the right way to raise an exception. Usually seen in code as `rescue Error => e` 
May be inefficient because it turns all output into potential `hostnames`