### PR TITLE
Fix spaces for envvars in submit.yml.erb

### DIFF
--- a/lib/ood_core/job/adapters/torque.rb
+++ b/lib/ood_core/job/adapters/torque.rb
@@ -1,5 +1,6 @@
 require "ood_core/refinements/hash_extensions"
 require "ood_core/job/adapters/helper"
+require 'shellwords'
 
 module OodCore
   module Job
@@ -128,6 +129,9 @@ module OodCore
               resources.merge! script.native.fetch(:resources, {})
               envvars.merge!   script.native.fetch(:envvars, {})
             end
+
+            # Destructively change envvars to shellescape values
+            envvars.each { |k, v| envvars[k] = Shellwords.escape(v)}
 
             # Submit job
             @pbs.submit_string(script.content, queue: script.queue_name, headers: headers, resources: resources, envvars: envvars)

--- a/lib/ood_core/job/adapters/torque.rb
+++ b/lib/ood_core/job/adapters/torque.rb
@@ -131,7 +131,7 @@ module OodCore
             end
 
             # Destructively change envvars to shellescape values
-            envvars.each { |k, v| envvars[k] = Shellwords.escape(v)}
+            envvars.transform_values! { |v| Shellwords.escape(v) }
 
             # Submit job
             @pbs.submit_string(script.content, queue: script.queue_name, headers: headers, resources: resources, envvars: envvars)

--- a/spec/job/adapters/torque_spec.rb
+++ b/spec/job/adapters/torque_spec.rb
@@ -317,6 +317,12 @@ describe OodCore::Job::Adapters::Torque do
         it { expect(pbs).to have_received(:submit_string).with(content, queue: nil, headers: {Join_Path: "oe"}, resources: {}, envvars: {"key" => "value"}) }
       end
 
+      context "with :job_environment having spaces" do
+        before { adapter.submit(build_script(job_environment: {"key" => "value value"})) }
+
+        it { expect(pbs).to have_received(:submit_string).with(content, queue: nil, headers: {Join_Path: "oe"}, resources: {}, envvars: {"key" => "value\\ value"}) }
+      end
+
       context "with :workdir" do
         before { adapter.submit(build_script(workdir: "/path/to/workdir")) }
 


### PR DESCRIPTION
Used `Shellwords.escape`