### PR TITLE
Lha timing bug

### DIFF
--- a/lib/ood_core/job/adapters/linux_host/launcher.rb
+++ b/lib/ood_core/job/adapters/linux_host/launcher.rb
@@ -166,7 +166,7 @@ class OodCore::Job::Adapters::LinuxHost::Launcher
         'email_on_terminated' => script_email_on_event(script, 'terminated'),
         'email_on_start' => script_email_on_event(script, 'started'),
         'environment' => export_env(script),
-        'error_path' => (script.error_path) ? script.error_path.to_s : '/dev/null',
+        'error_path' => error_path(script),
         'job_name' => script.job_name.to_s,
         'output_path' => (script.output_path) ? script.output_path.to_s : '/dev/null',
         'script_content' => content,
@@ -271,5 +271,12 @@ class OodCore::Job::Adapters::LinuxHost::Launcher
   def user_script_has_shebang?(script)
     return false if script.content.empty?
     script.content.split("\n").first.start_with?('#!/')
+  end
+
+  def error_path(script)
+    return script.error_path.to_s if script.error_path
+    return script.output_path.to_s if script.output_path
+
+    '/dev/null'
   end
 end

--- a/lib/ood_core/job/adapters/linux_host/launcher.rb
+++ b/lib/ood_core/job/adapters/linux_host/launcher.rb
@@ -176,6 +176,7 @@ class OodCore::Job::Adapters::LinuxHost::Launcher
         'singularity_image' => singularity_image(script.native),
         'ssh_hosts' => ssh_hosts,
         'tmux_bin' => tmux_bin,
+        'workdir' => (script.workdir) ? script.workdir.to_s : '/tmp',
       }.each{
         |key, value| bnd.local_variable_set(key, value)
       }

--- a/lib/ood_core/job/adapters/linux_host/templates/script_wrapper.erb.sh
+++ b/lib/ood_core/job/adapters/linux_host/templates/script_wrapper.erb.sh
@@ -16,13 +16,9 @@ fi
 echo $hostname
 
 # Put the script into a temp file on localhost
-<% if debug %>
-singularity_tmp_file=$(mktemp -p "$HOME" --suffix '_sing')
-tmux_tmp_file=$(mktemp -p "$HOME" --suffix "_tmux")
-<% else %>
-singularity_tmp_file=$(mktemp)
-tmux_tmp_file=$(mktemp)
-<% end %>
+singularity_tmp_file=$(mktemp -p "<%= workdir %>" --suffix '_sing')
+tmux_tmp_file=$(mktemp -p "<%= workdir %>" --suffix "_tmux")
+
 
 # Create an executable to run in a tmux session
 # The escaped HEREDOC means that we need to substitute in $singularity_tmp_file ourselves
@@ -69,10 +65,3 @@ SINGULARITY_LAUNCHER
 chmod +x "$singularity_tmp_file"
 chmod +x "$tmux_tmp_file"
 <%= tmux_bin %> new-session -d -s "<%= session_name %>" "$tmux_tmp_file"
-
-# Remove the file
-<% if ! debug %>
-# Wait 1 second to ensure that tmux session has started before the file is removed
-sleep 1
-rm -f "$tmux_tmp_file"; rm -f "$singularity_tmp_file"
-<% end %>

--- a/spec/job/adapters/linux_host/launcher_spec.rb
+++ b/spec/job/adapters/linux_host/launcher_spec.rb
@@ -296,12 +296,23 @@ describe OodCore::Job::Adapters::LinuxHost::Launcher do
                 }), 'session_name')
             }
 
+            let(:script_with_both_paths_nil) {
+                subject.send(:wrapped_script, build_script({
+                    error_path: nil,
+                    output_path: nil,
+                }), 'session_name')
+            }
+
             it "is set in the script" do
                 expect(script_with_explicit_error_path).to include('ERROR_PATH=/home/efranz/stderr.log')
             end
 
-            it "is not set in the script" do
-                expect(script_with_nil_error_path).to include('ERROR_PATH=/dev/null')
+            it "is not set in the script when there's no output_path" do
+                expect(script_with_both_paths_nil).to include('ERROR_PATH=/dev/null')
+            end
+
+            it "uses output_path if it exists" do
+                expect(script_with_nil_error_path).to include('ERROR_PATH=/users/PZS0002/mrodgers/stdout_from_fork.log')
             end
         end
 


### PR DESCRIPTION
Fixes #211 

Initially I'd added some complexity to look into the tmux pstree to see if singularity had started, but now I'm just thinking why not just keep the files in the `workdir`?  The `debug` flag won't really do much now, but there's no race condition and it'll mean we can always debug.