### PR TITLE
replace travis ci with gh actions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,32 @@
+name: Unit Tests
+
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+    branches:
+      - master
+
+jobs:
+  tests:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: checkout
+        uses: actions/checkout@v2
+      - uses: actions/setup-ruby@v1
+        with:
+          ruby-version: '2.5'
+      - uses: actions/cache@v2
+        with:
+          path: ~/vendor/bundle
+          key: ${{ runner.os }}-gems-${{ hashFiles('Gemfile.lock') }}
+      - name: setup bundler
+        run: |
+          gem install bundler -v 1.17.3
+          bundle config path ~/vendor/bundle
+      - name: install gems
+        run: bundle install
+      - name: test
+        run: bundle exec rake spec

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,0 @@
-sudo: false
-language: ruby
-rvm:
-  - 2.5.5
-before_install: gem install bundler -v '~> 1.17'
-notifications:
-  email:
-    on_success: never
-    on_failure: always

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # OodCore
 
-[![Build Status](https://travis-ci.org/OSC/ood_core.svg?branch=master)](https://travis-ci.org/OSC/ood_core)
+[![Build Status](https://github.com/osc/ood_core/workflows/Unit%20Tests/badge.svg)](https://github.com/OSC/ood_core/actions?query=workflow%3A%22Unit+Tests%22)
 ![GitHub Release](https://img.shields.io/github/release/osc/ood_core.svg)
 ![GitHub License](https://img.shields.io/github/license/osc/ood_core.svg)
 


### PR DESCRIPTION
replace travis ci with gh actions. This is just testing now, but we should look into publishing the gem automatically too afterwards.