### PR TITLE
Support defining pod lifetime for Kubernetes

### DIFF
--- a/lib/ood_core/job/adapters/kubernetes/helper.rb
+++ b/lib/ood_core/job/adapters/kubernetes/helper.rb
@@ -118,6 +118,10 @@ class OodCore::Job::Adapters::Kubernetes::Helper
     id + '-configmap'
   end
 
+  def seconds_to_duration(s)
+    "%02dh%02dm%02ds" % [s / 3600, s / 60 % 60, s % 60]
+  end
+
   # Extract pod info from json data. The data is expected to be from the kubectl
   # command and conform to kubernetes' datatype structures.
   #

--- a/lib/ood_core/job/adapters/kubernetes/templates/pod.yml.erb
+++ b/lib/ood_core/job/adapters/kubernetes/templates/pod.yml.erb
@@ -10,6 +10,10 @@ metadata:
     <%- if !script.accounting_id.nil? && script.accounting_id != "" -%>
     account: <%= script.accounting_id %>
     <%- end -%>
+  annotations:
+    <%- unless script.wall_time.nil? -%>
+    pod.kubernetes.io/lifetime: <%= helper.seconds_to_duration(script.wall_time) %>
+    <%- end -%>
 spec:
   restartPolicy: <%= spec.container.restart_policy %>
   securityContext:

--- a/lib/ood_core/job/adapters/kubernetes/templates/pod.yml.erb
+++ b/lib/ood_core/job/adapters/kubernetes/templates/pod.yml.erb
@@ -108,6 +108,8 @@ kind: Service
 metadata:
   name: <%= service_name(id) %>
   namespace: <%= namespace %>
+  labels:
+    job: <%= id %>
 spec:
   selector:
     job: <%= id %>
@@ -124,6 +126,8 @@ kind: ConfigMap
 metadata:
   name: <%= configmap_name(id) %>
   namespace: <%= namespace %>
+  labels:
+    job: <%= id %>
 data:
   <%= configmap.filename %>: |
     <% config_data_lines(configmap.data).each do |line| %><%= line %><% end %>

--- a/spec/fixtures/output/k8s/expected_pod_create.yml
+++ b/spec/fixtures/output/k8s/expected_pod_create.yml
@@ -84,6 +84,8 @@ kind: Service
 metadata:
   name: rspec-test-123-service
   namespace: testuser
+  labels:
+    job: rspec-test-123
 spec:
   selector:
     job: rspec-test-123
@@ -98,6 +100,8 @@ kind: ConfigMap
 metadata:
   name: rspec-test-123-configmap
   namespace: testuser
+  labels:
+    job: rspec-test-123
 data:
   config.file: |
     a = b

--- a/spec/fixtures/output/k8s/expected_pod_create.yml
+++ b/spec/fixtures/output/k8s/expected_pod_create.yml
@@ -8,6 +8,7 @@ metadata:
     app.kubernetes.io/name: rspec-test
     app.kubernetes.io/managed-by: open-ondemand
     account: test
+  annotations:
 spec:
   restartPolicy: Always
   securityContext:

--- a/spec/job/adapters/kubernetes/helper_spec.rb
+++ b/spec/job/adapters/kubernetes/helper_spec.rb
@@ -386,6 +386,14 @@ describe OodCore::Job::Adapters::Kubernetes::Helper do
     end
   end
 
+  describe "#seconds_to_duration" do
+    it "handles seconds to duration" do
+      expect(helper.seconds_to_duration(3600)).to eq('01h00m00s')
+      expect(helper.seconds_to_duration(3660)).to eq('01h01m00s')
+      expect(helper.seconds_to_duration(3662)).to eq('01h01m02s')
+    end
+  end
+
   describe "#pod_info_from_json" do
     it "correctly reads a running pods' info" do
       allow(DateTime).to receive(:now).and_return(now)


### PR DESCRIPTION
I opted to use easier to read format like `1h5m` rather than just do everything as seconds.  If preferred could just as easily make everything seconds, so 3600 would become `3600s` (`s` suffix).

Also verified `annotations` with no key/value pairs does work.