### PR TITLE
Helper namespace

### DIFF
--- a/lib/ood_core/job/adapters/kubernetes.rb
+++ b/lib/ood_core/job/adapters/kubernetes.rb
@@ -7,7 +7,7 @@ module OodCore
       using Refinements::HashExtensions
 
       def self.build_kubernetes(config)
-        batch = Adapters::Kubernetes::Batch.new(config.to_h.symbolize_keys, Adapters::Kubernetes::Helper.new)
+        batch = Adapters::Kubernetes::Batch.new(config.to_h.symbolize_keys)
         Adapters::Kubernetes.new(batch)
       end
     end

--- a/lib/ood_core/job/adapters/kubernetes/batch.rb
+++ b/lib/ood_core/job/adapters/kubernetes/batch.rb
@@ -16,7 +16,7 @@ class OodCore::Job::Adapters::Kubernetes::Batch
   attr_reader :all_namespaces, :using_context, :helper
   attr_reader :username_prefix, :namespace_prefix
 
-  def initialize(options = {}, helper = Helper.new)
+  def initialize(options = {})
     options = options.to_h.symbolize_keys
 
     @config_file = options.fetch(:config_file, default_config_file)
@@ -28,7 +28,7 @@ class OodCore::Job::Adapters::Kubernetes::Batch
     @namespace_prefix = options.fetch(:namespace_prefix, '')
 
     @using_context = false
-    @helper = helper
+    @helper = Helper.new
 
     begin
       make_kubectl_config(options)

--- a/lib/ood_core/job/adapters/kubernetes/batch.rb
+++ b/lib/ood_core/job/adapters/kubernetes/batch.rb
@@ -206,11 +206,7 @@ class OodCore::Job::Adapters::Kubernetes::Batch
   end
 
   def namespace
-    default_namespace
-  end
-
-  def default_namespace
-    namespace_prefix + username
+    "#{namespace_prefix}#{username}"
   end
 
   def context

--- a/spec/fixtures/output/k8s/ns_prefixed_pod.json
+++ b/spec/fixtures/output/k8s/ns_prefixed_pod.json
@@ -1,0 +1,608 @@
+{
+    "apiVersion": "v1",
+    "kind": "Pod",
+    "metadata": {
+        "annotations": {
+            "cni.projectcalico.org/podIP": "192.168.255.232/32",
+            "cni.projectcalico.org/podIPs": "192.168.255.232/32",
+            "pod.kubernetes.io/lifetime": "03h00m00s"
+        },
+        "creationTimestamp": "2020-12-10T21:51:58Z",
+        "labels": {
+            "account": "PZS0714",
+            "app.kubernetes.io/managed-by": "open-ondemand",
+            "app.kubernetes.io/name": "jupyter",
+            "job": "jupyter-3o4n6z3e"
+        },
+        "managedFields": [
+            {
+                "apiVersion": "v1",
+                "fieldsType": "FieldsV1",
+                "fieldsV1": {
+                    "f:metadata": {
+                        "f:annotations": {
+                            "f:cni.projectcalico.org/podIP": {},
+                            "f:cni.projectcalico.org/podIPs": {}
+                        }
+                    }
+                },
+                "manager": "calico",
+                "operation": "Update",
+                "time": "2020-12-10T21:51:58Z"
+            },
+            {
+                "apiVersion": "v1",
+                "fieldsType": "FieldsV1",
+                "fieldsV1": {
+                    "f:metadata": {
+                        "f:annotations": {
+                            ".": {},
+                            "f:pod.kubernetes.io/lifetime": {}
+                        },
+                        "f:labels": {
+                            ".": {},
+                            "f:account": {},
+                            "f:app.kubernetes.io/managed-by": {},
+                            "f:app.kubernetes.io/name": {},
+                            "f:job": {}
+                        }
+                    },
+                    "f:spec": {
+                        "f:containers": {
+                            "k:{\"name\":\"jupyter\"}": {
+                                ".": {},
+                                "f:command": {},
+                                "f:env": {
+                                    ".": {},
+                                    "k:{\"name\":\"HOME\"}": {
+                                        ".": {},
+                                        "f:name": {},
+                                        "f:value": {}
+                                    },
+                                    "k:{\"name\":\"NB_GID\"}": {
+                                        ".": {},
+                                        "f:name": {},
+                                        "f:value": {}
+                                    },
+                                    "k:{\"name\":\"NB_UID\"}": {
+                                        ".": {},
+                                        "f:name": {},
+                                        "f:value": {}
+                                    },
+                                    "k:{\"name\":\"NB_USER\"}": {
+                                        ".": {},
+                                        "f:name": {},
+                                        "f:value": {}
+                                    }
+                                },
+                                "f:image": {},
+                                "f:imagePullPolicy": {},
+                                "f:name": {},
+                                "f:ports": {
+                                    ".": {},
+                                    "k:{\"containerPort\":8080,\"protocol\":\"TCP\"}": {
+                                        ".": {},
+                                        "f:containerPort": {},
+                                        "f:protocol": {}
+                                    }
+                                },
+                                "f:resources": {
+                                    ".": {},
+                                    "f:limits": {
+                                        ".": {},
+                                        "f:cpu": {},
+                                        "f:memory": {}
+                                    },
+                                    "f:requests": {
+                                        ".": {},
+                                        "f:cpu": {},
+                                        "f:memory": {}
+                                    }
+                                },
+                                "f:terminationMessagePath": {},
+                                "f:terminationMessagePolicy": {},
+                                "f:volumeMounts": {
+                                    ".": {},
+                                    "k:{\"mountPath\":\"/ood\"}": {
+                                        ".": {},
+                                        "f:mountPath": {},
+                                        "f:name": {}
+                                    },
+                                    "k:{\"mountPath\":\"/users\"}": {
+                                        ".": {},
+                                        "f:mountPath": {},
+                                        "f:name": {}
+                                    }
+                                },
+                                "f:workingDir": {}
+                            }
+                        },
+                        "f:dnsPolicy": {},
+                        "f:enableServiceLinks": {},
+                        "f:initContainers": {
+                            ".": {},
+                            "k:{\"name\":\"add-hostport-to-cfg\"}": {
+                                ".": {},
+                                "f:command": {},
+                                "f:image": {},
+                                "f:imagePullPolicy": {},
+                                "f:name": {},
+                                "f:resources": {},
+                                "f:terminationMessagePath": {},
+                                "f:terminationMessagePolicy": {},
+                                "f:volumeMounts": {
+                                    ".": {},
+                                    "k:{\"mountPath\":\"/ood\"}": {
+                                        ".": {},
+                                        "f:mountPath": {},
+                                        "f:name": {}
+                                    },
+                                    "k:{\"mountPath\":\"/users\"}": {
+                                        ".": {},
+                                        "f:mountPath": {},
+                                        "f:name": {}
+                                    }
+                                }
+                            },
+                            "k:{\"name\":\"add-passwd-to-cfg\"}": {
+                                ".": {},
+                                "f:command": {},
+                                "f:image": {},
+                                "f:imagePullPolicy": {},
+                                "f:name": {},
+                                "f:resources": {},
+                                "f:terminationMessagePath": {},
+                                "f:terminationMessagePolicy": {},
+                                "f:volumeMounts": {
+                                    ".": {},
+                                    "k:{\"mountPath\":\"/ood\"}": {
+                                        ".": {},
+                                        "f:mountPath": {},
+                                        "f:name": {}
+                                    },
+                                    "k:{\"mountPath\":\"/users\"}": {
+                                        ".": {},
+                                        "f:mountPath": {},
+                                        "f:name": {}
+                                    }
+                                }
+                            },
+                            "k:{\"name\":\"init-secret\"}": {
+                                ".": {},
+                                "f:command": {},
+                                "f:image": {},
+                                "f:imagePullPolicy": {},
+                                "f:name": {},
+                                "f:resources": {},
+                                "f:terminationMessagePath": {},
+                                "f:terminationMessagePolicy": {},
+                                "f:volumeMounts": {
+                                    ".": {},
+                                    "k:{\"mountPath\":\"/ood\"}": {
+                                        ".": {},
+                                        "f:mountPath": {},
+                                        "f:name": {}
+                                    },
+                                    "k:{\"mountPath\":\"/users\"}": {
+                                        ".": {},
+                                        "f:mountPath": {},
+                                        "f:name": {}
+                                    }
+                                }
+                            }
+                        },
+                        "f:restartPolicy": {},
+                        "f:schedulerName": {},
+                        "f:securityContext": {
+                            ".": {},
+                            "f:fsGroup": {},
+                            "f:runAsGroup": {},
+                            "f:runAsUser": {}
+                        },
+                        "f:terminationGracePeriodSeconds": {},
+                        "f:volumes": {
+                            ".": {},
+                            "k:{\"name\":\"configmap-volume\"}": {
+                                ".": {},
+                                "f:configMap": {
+                                    ".": {},
+                                    "f:defaultMode": {},
+                                    "f:name": {}
+                                },
+                                "f:name": {}
+                            },
+                            "k:{\"name\":\"home\"}": {
+                                ".": {},
+                                "f:hostPath": {
+                                    ".": {},
+                                    "f:path": {},
+                                    "f:type": {}
+                                },
+                                "f:name": {}
+                            }
+                        }
+                    }
+                },
+                "manager": "kubectl-create",
+                "operation": "Update",
+                "time": "2020-12-10T21:51:58Z"
+            },
+            {
+                "apiVersion": "v1",
+                "fieldsType": "FieldsV1",
+                "fieldsV1": {
+                    "f:status": {
+                        "f:conditions": {
+                            "k:{\"type\":\"ContainersReady\"}": {
+                                ".": {},
+                                "f:lastProbeTime": {},
+                                "f:lastTransitionTime": {},
+                                "f:status": {},
+                                "f:type": {}
+                            },
+                            "k:{\"type\":\"Initialized\"}": {
+                                ".": {},
+                                "f:lastProbeTime": {},
+                                "f:lastTransitionTime": {},
+                                "f:status": {},
+                                "f:type": {}
+                            },
+                            "k:{\"type\":\"Ready\"}": {
+                                ".": {},
+                                "f:lastProbeTime": {},
+                                "f:lastTransitionTime": {},
+                                "f:status": {},
+                                "f:type": {}
+                            }
+                        },
+                        "f:containerStatuses": {},
+                        "f:hostIP": {},
+                        "f:initContainerStatuses": {},
+                        "f:phase": {},
+                        "f:podIP": {},
+                        "f:podIPs": {
+                            ".": {},
+                            "k:{\"ip\":\"192.168.255.232\"}": {
+                                ".": {},
+                                "f:ip": {}
+                            }
+                        },
+                        "f:startTime": {}
+                    }
+                },
+                "manager": "kubelet",
+                "operation": "Update",
+                "time": "2020-12-10T22:08:44Z"
+            }
+        ],
+        "name": "jupyter-3o4n6z3e",
+        "namespace": "user-johrstrom",
+        "resourceVersion": "65882929",
+        "selfLink": "/api/v1/namespaces/user-johrstrom/pods/jupyter-3o4n6z3e",
+        "uid": "2cbb542b-4611-4391-bef2-fb3a9246c371"
+    },
+    "spec": {
+        "containers": [
+            {
+                "command": [
+                    "/usr/local/bin/start.sh",
+                    "/opt/conda/bin/jupyter",
+                    "notebook",
+                    "--config=/ood/ondemand_config.py"
+                ],
+                "env": [
+                    {
+                        "name": "NB_UID",
+                        "value": "30961"
+                    },
+                    {
+                        "name": "NB_USER",
+                        "value": "johrstrom"
+                    },
+                    {
+                        "name": "NB_GID",
+                        "value": "5515"
+                    },
+                    {
+                        "name": "HOME",
+                        "value": "/users/PZS0714/johrstrom"
+                    }
+                ],
+                "image": "jupyter/scipy-notebook",
+                "imagePullPolicy": "IfNotPresent",
+                "name": "jupyter",
+                "ports": [
+                    {
+                        "containerPort": 8080,
+                        "protocol": "TCP"
+                    }
+                ],
+                "resources": {
+                    "limits": {
+                        "cpu": "1",
+                        "memory": "4Gi"
+                    },
+                    "requests": {
+                        "cpu": "1",
+                        "memory": "4Gi"
+                    }
+                },
+                "terminationMessagePath": "/dev/termination-log",
+                "terminationMessagePolicy": "File",
+                "volumeMounts": [
+                    {
+                        "mountPath": "/ood",
+                        "name": "configmap-volume"
+                    },
+                    {
+                        "mountPath": "/users",
+                        "name": "home"
+                    },
+                    {
+                        "mountPath": "/var/run/secrets/kubernetes.io/serviceaccount",
+                        "name": "default-token-2m9mp",
+                        "readOnly": true
+                    }
+                ],
+                "workingDir": "/users/PZS0714/johrstrom"
+            }
+        ],
+        "dnsPolicy": "ClusterFirst",
+        "enableServiceLinks": true,
+        "initContainers": [
+            {
+                "command": [
+                    "/bin/save_passwd_as_secret",
+                    "user-johrstrom"
+                ],
+                "image": "jeffohrstrom/ood-k8s-utils:2.6",
+                "imagePullPolicy": "IfNotPresent",
+                "name": "init-secret",
+                "resources": {},
+                "terminationMessagePath": "/dev/termination-log",
+                "terminationMessagePolicy": "File",
+                "volumeMounts": [
+                    {
+                        "mountPath": "/ood",
+                        "name": "configmap-volume"
+                    },
+                    {
+                        "mountPath": "/users",
+                        "name": "home"
+                    },
+                    {
+                        "mountPath": "/var/run/secrets/kubernetes.io/serviceaccount",
+                        "name": "default-token-2m9mp",
+                        "readOnly": true
+                    }
+                ]
+            },
+            {
+                "command": [
+                    "/bin/bash",
+                    "-c",
+                    "sleep 1000; source /bin/passwd_from_secret; source /bin/create_salt_and_sha1; /bin/add_line_to_configmap \"c.NotebookApp.password=u'sha1:${SALT}:${PASSWORD_SHA1}'\" ondemand_config.py"
+                ],
+                "image": "jeffohrstrom/ood-k8s-utils:2.6",
+                "imagePullPolicy": "IfNotPresent",
+                "name": "add-passwd-to-cfg",
+                "resources": {},
+                "terminationMessagePath": "/dev/termination-log",
+                "terminationMessagePolicy": "File",
+                "volumeMounts": [
+                    {
+                        "mountPath": "/ood",
+                        "name": "configmap-volume"
+                    },
+                    {
+                        "mountPath": "/users",
+                        "name": "home"
+                    },
+                    {
+                        "mountPath": "/var/run/secrets/kubernetes.io/serviceaccount",
+                        "name": "default-token-2m9mp",
+                        "readOnly": true
+                    }
+                ]
+            },
+            {
+                "command": [
+                    "/bin/bash",
+                    "-c",
+                    "source /bin/find_host_port; /bin/add_line_to_configmap \"c.NotebookApp.base_url='/node/${HOST_CFG}/${PORT_CFG}/'\" ondemand_config.py"
+                ],
+                "image": "jeffohrstrom/ood-k8s-utils:2.6",
+                "imagePullPolicy": "IfNotPresent",
+                "name": "add-hostport-to-cfg",
+                "resources": {},
+                "terminationMessagePath": "/dev/termination-log",
+                "terminationMessagePolicy": "File",
+                "volumeMounts": [
+                    {
+                        "mountPath": "/ood",
+                        "name": "configmap-volume"
+                    },
+                    {
+                        "mountPath": "/users",
+                        "name": "home"
+                    },
+                    {
+                        "mountPath": "/var/run/secrets/kubernetes.io/serviceaccount",
+                        "name": "default-token-2m9mp",
+                        "readOnly": true
+                    }
+                ]
+            }
+        ],
+        "nodeName": "kubeworker01-dev",
+        "preemptionPolicy": "PreemptLowerPriority",
+        "priority": 0,
+        "restartPolicy": "OnFailure",
+        "schedulerName": "default-scheduler",
+        "securityContext": {
+            "fsGroup": 5515,
+            "runAsGroup": 5515,
+            "runAsUser": 30961
+        },
+        "serviceAccount": "default",
+        "serviceAccountName": "default",
+        "terminationGracePeriodSeconds": 30,
+        "tolerations": [
+            {
+                "effect": "NoExecute",
+                "key": "node.kubernetes.io/not-ready",
+                "operator": "Exists",
+                "tolerationSeconds": 300
+            },
+            {
+                "effect": "NoExecute",
+                "key": "node.kubernetes.io/unreachable",
+                "operator": "Exists",
+                "tolerationSeconds": 300
+            }
+        ],
+        "volumes": [
+            {
+                "configMap": {
+                    "defaultMode": 420,
+                    "name": "jupyter-3o4n6z3e-configmap"
+                },
+                "name": "configmap-volume"
+            },
+            {
+                "hostPath": {
+                    "path": "/users",
+                    "type": "Directory"
+                },
+                "name": "home"
+            },
+            {
+                "name": "default-token-2m9mp",
+                "secret": {
+                    "defaultMode": 420,
+                    "secretName": "default-token-2m9mp"
+                }
+            }
+        ]
+    },
+    "status": {
+        "conditions": [
+            {
+                "lastProbeTime": null,
+                "lastTransitionTime": "2020-12-10T22:08:42Z",
+                "status": "True",
+                "type": "Initialized"
+            },
+            {
+                "lastProbeTime": null,
+                "lastTransitionTime": "2020-12-10T22:08:44Z",
+                "status": "True",
+                "type": "Ready"
+            },
+            {
+                "lastProbeTime": null,
+                "lastTransitionTime": "2020-12-10T22:08:44Z",
+                "status": "True",
+                "type": "ContainersReady"
+            },
+            {
+                "lastProbeTime": null,
+                "lastTransitionTime": "2020-12-10T21:51:58Z",
+                "status": "True",
+                "type": "PodScheduled"
+            }
+        ],
+        "containerStatuses": [
+            {
+                "containerID": "containerd://f0c67be579074186c88aa853885b7310c12d164661f44ff03621b3d89996f6e1",
+                "image": "docker.io/jupyter/scipy-notebook:latest",
+                "imageID": "docker.io/jupyter/scipy-notebook@sha256:c390a33cd355ae5c053c78f4f6bfbc1dccb0405c4629756e6c3ca6457751707c",
+                "lastState": {
+                    "terminated": {
+                        "containerID": "containerd://7b5f0321c1d922ef36fef13b2e55544a060d49c66b5146cb88dc36993503091d",
+                        "exitCode": 128,
+                        "finishedAt": "2020-12-10T22:08:43Z",
+                        "message": "failed to create containerd task: OCI runtime create failed: container_linux.go:349: starting container process caused \"process_linux.go:449: container init caused \\\"mkdir /users/PZS0714/johrstrom: too many levels of symbolic links\\\"\": unknown",
+                        "reason": "StartError",
+                        "startedAt": "1970-01-01T00:00:00Z"
+                    }
+                },
+                "name": "jupyter",
+                "ready": true,
+                "restartCount": 1,
+                "started": true,
+                "state": {
+                    "running": {
+                        "startedAt": "2020-12-10T22:08:43Z"
+                    }
+                }
+            }
+        ],
+        "hostIP": "192.148.247.227",
+        "initContainerStatuses": [
+            {
+                "containerID": "containerd://f825d16508ed2950b38b850552e7ed859553145f2e7bd3073089bbcd2e963f44",
+                "image": "docker.io/jeffohrstrom/ood-k8s-utils:2.6",
+                "imageID": "docker.io/jeffohrstrom/ood-k8s-utils@sha256:ac52a7b0bf5bc60def4d4d438560712cd2be8be4299b74493f7078fde84bf80b",
+                "lastState": {},
+                "name": "init-secret",
+                "ready": true,
+                "restartCount": 0,
+                "state": {
+                    "terminated": {
+                        "containerID": "containerd://f825d16508ed2950b38b850552e7ed859553145f2e7bd3073089bbcd2e963f44",
+                        "exitCode": 0,
+                        "finishedAt": "2020-12-10T21:51:59Z",
+                        "reason": "Completed",
+                        "startedAt": "2020-12-10T21:51:59Z"
+                    }
+                }
+            },
+            {
+                "containerID": "containerd://fcacf8bee238a92fcbd75a13c76c34698863111a6219b25096b96cd889e50e96",
+                "image": "docker.io/jeffohrstrom/ood-k8s-utils:2.6",
+                "imageID": "docker.io/jeffohrstrom/ood-k8s-utils@sha256:ac52a7b0bf5bc60def4d4d438560712cd2be8be4299b74493f7078fde84bf80b",
+                "lastState": {},
+                "name": "add-passwd-to-cfg",
+                "ready": true,
+                "restartCount": 0,
+                "state": {
+                    "terminated": {
+                        "containerID": "containerd://fcacf8bee238a92fcbd75a13c76c34698863111a6219b25096b96cd889e50e96",
+                        "exitCode": 0,
+                        "finishedAt": "2020-12-10T22:08:40Z",
+                        "reason": "Completed",
+                        "startedAt": "2020-12-10T21:52:00Z"
+                    }
+                }
+            },
+            {
+                "containerID": "containerd://bcc78cedca3401a91afd2ffd393198849b169e5230b191b04c0b395256ece73e",
+                "image": "docker.io/jeffohrstrom/ood-k8s-utils:2.6",
+                "imageID": "docker.io/jeffohrstrom/ood-k8s-utils@sha256:ac52a7b0bf5bc60def4d4d438560712cd2be8be4299b74493f7078fde84bf80b",
+                "lastState": {},
+                "name": "add-hostport-to-cfg",
+                "ready": true,
+                "restartCount": 0,
+                "state": {
+                    "terminated": {
+                        "containerID": "containerd://bcc78cedca3401a91afd2ffd393198849b169e5230b191b04c0b395256ece73e",
+                        "exitCode": 0,
+                        "finishedAt": "2020-12-10T22:08:42Z",
+                        "reason": "Completed",
+                        "startedAt": "2020-12-10T22:08:41Z"
+                    }
+                }
+            }
+        ],
+        "phase": "Running",
+        "podIP": "192.168.255.232",
+        "podIPs": [
+            {
+                "ip": "192.168.255.232"
+            }
+        ],
+        "qosClass": "Burstable",
+        "startTime": "2020-12-10T21:51:58Z"
+    }
+}

--- a/spec/fixtures/output/k8s/pod_yml_from_all_configs.yml
+++ b/spec/fixtures/output/k8s/pod_yml_from_all_configs.yml
@@ -1,0 +1,109 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  namespace: user-testuser
+  name: rspec-test-123
+  labels:
+    job: rspec-test-123
+    app.kubernetes.io/name: rspec-test
+    app.kubernetes.io/managed-by: open-ondemand
+    account: test
+  annotations:
+spec:
+  restartPolicy: Always
+  securityContext:
+    runAsUser: 1001
+    runAsGroup: 1002
+    fsGroup: 1002
+  containers:
+  - name: "rspec-test"
+    image: ruby:2.5
+    imagePullPolicy: IfNotPresent
+    workingDir: "/my/home"
+    env:
+    - name: HOME
+      value: "/my/home"
+    - name: PATH
+      value: "/usr/bin:/usr/local/bin"
+    command:
+    - "rake"
+    - "spec"
+    ports:
+    - containerPort: 8080
+    volumeMounts:
+    - name: configmap-volume
+      mountPath:  /ood
+    - name: home-dir
+      mountPath: /home
+    - name: nfs-dir
+      mountPath: /fs
+    - name: ess
+      mountPath: /fs/ess
+    resources:
+      limits:
+        memory: "6Gi"
+        cpu: "4"
+      requests:
+        memory: "6Gi"
+        cpu: "4"
+  initContainers:
+  - name: "init-1"
+    image: "busybox:latest"
+    command:
+    - "/bin/ls"
+    - "-lrt"
+    - "."
+    volumeMounts:
+    - name: configmap-volume
+      mountPath:  /ood
+    - name: home-dir
+      mountPath: /home
+    - name: nfs-dir
+      mountPath: /fs
+    - name: ess
+      mountPath: /fs/ess
+  volumes:
+  - name: configmap-volume
+    configMap:
+      name: rspec-test-123-configmap
+  - name: home-dir
+    hostPath:
+      path: /users
+      type: Directory
+  - name: nfs-dir
+    nfs:
+      server: some.nfs.host
+      path: /fs
+  - name: ess
+    hostPath:
+      path: /fs/ess
+      type: Directory
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: rspec-test-123-service
+  namespace: user-testuser
+  labels:
+    job: rspec-test-123
+spec:
+  selector:
+    job: rspec-test-123
+  ports:
+  - protocol: TCP
+    port: 80
+    targetPort: 8080
+  type: NodePort
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: rspec-test-123-configmap
+  namespace: user-testuser
+  labels:
+    job: rspec-test-123
+data:
+  config.file: |
+    a = b
+    c = d
+      indentation = keepthis

--- a/spec/fixtures/output/k8s/pod_yml_from_defaults.yml
+++ b/spec/fixtures/output/k8s/pod_yml_from_defaults.yml
@@ -8,6 +8,7 @@ metadata:
     app.kubernetes.io/name: rspec-test
     app.kubernetes.io/managed-by: open-ondemand
     account: test
+  annotations:
 spec:
   restartPolicy: Always
   securityContext:
@@ -67,6 +68,8 @@ kind: Service
 metadata:
   name: rspec-test-123-service
   namespace: testuser
+  labels:
+    job: rspec-test-123
 spec:
   selector:
     job: rspec-test-123
@@ -81,6 +84,8 @@ kind: ConfigMap
 metadata:
   name: rspec-test-123-configmap
   namespace: testuser
+  labels:
+    job: rspec-test-123
 data:
   config.file: |
     a = b

--- a/spec/fixtures/output/k8s/pod_yml_from_defaults.yml
+++ b/spec/fixtures/output/k8s/pod_yml_from_defaults.yml
@@ -8,7 +8,6 @@ metadata:
     app.kubernetes.io/name: rspec-test
     app.kubernetes.io/managed-by: open-ondemand
     account: test
-  annotations:
 spec:
   restartPolicy: Always
   securityContext:
@@ -33,10 +32,6 @@ spec:
     volumeMounts:
     - name: configmap-volume
       mountPath:  /ood
-    - name: home-dir
-      mountPath: /home
-    - name: nfs-dir
-      mountPath: /fs
     - name: ess
       mountPath: /fs/ess
     resources:
@@ -56,24 +51,12 @@ spec:
     volumeMounts:
     - name: configmap-volume
       mountPath:  /ood
-    - name: home-dir
-      mountPath: /home
-    - name: nfs-dir
-      mountPath: /fs
     - name: ess
       mountPath: /fs/ess
   volumes:
   - name: configmap-volume
     configMap:
       name: rspec-test-123-configmap
-  - name: home-dir
-    hostPath:
-      path: /users
-      type: Directory
-  - name: nfs-dir
-    nfs:
-      server: some.nfs.host
-      path: /fs
   - name: ess
     hostPath:
       path: /fs/ess
@@ -84,8 +67,6 @@ kind: Service
 metadata:
   name: rspec-test-123-service
   namespace: testuser
-  labels:
-    job: rspec-test-123
 spec:
   selector:
     job: rspec-test-123
@@ -100,8 +81,6 @@ kind: ConfigMap
 metadata:
   name: rspec-test-123-configmap
   namespace: testuser
-  labels:
-    job: rspec-test-123
 data:
   config.file: |
     a = b

--- a/spec/job/adapters/kubernetes/batch_spec.rb
+++ b/spec/job/adapters/kubernetes/batch_spec.rb
@@ -68,8 +68,9 @@ describe OodCore::Job::Adapters::Kubernetes::Batch do
       stdin_data: ""
     ).and_return(['', '', $?])
 
-    @basic_batch = described_class.new({}, helper)
+    @basic_batch = described_class.new({})
     allow(@basic_batch).to receive(:username).and_return('testuser')
+    allow(@basic_batch).to receive(:helper).and_return(helper)
   end
 
   let(:configured_batch){
@@ -82,8 +83,9 @@ describe OodCore::Job::Adapters::Kubernetes::Batch do
       stdin_data: ""
     ).and_return(['', '', $?])
 
-    batch = described_class.new(config, helper)
+    batch = described_class.new(config)
     allow(batch).to receive(:username).and_return('testuser')
+    allow(batch).to receive(:helper).and_return(helper)
 
     batch
   }
@@ -415,8 +417,9 @@ describe OodCore::Job::Adapters::Kubernetes::Batch do
         stdin_data: ""
       ).and_return(['', '', $?])
 
-      batch = described_class.new({}, helper)
+      batch = described_class.new({})
       allow(batch).to receive(:username).and_return('testuser')
+      allow(batch).to receive(:helper).and_return(helper)
       allow(DateTime).to receive(:now).and_return(past)
 
       allow(Open3).to receive(:capture3).with(
@@ -452,7 +455,7 @@ describe OodCore::Job::Adapters::Kubernetes::Batch do
         stdin_data: ""
       ).and_return(['', '', $?])
 
-      batch = described_class.new({}, helper)
+      batch = described_class.new({})
       allow(batch).to receive(:username).and_return('testuser')
       allow(DateTime).to receive(:now).and_return(past)
 

--- a/spec/job/adapters/kubernetes/batch_spec.rb
+++ b/spec/job/adapters/kubernetes/batch_spec.rb
@@ -10,10 +10,12 @@ describe OodCore::Job::Adapters::Kubernetes::Batch do
     helper = Helper.new
     allow(helper).to receive(:get_host).with(nil).and_return(nil)
     allow(helper).to receive(:get_host).with('10.20.0.40').and_return('10.20.0.40')
+    allow(helper).to receive(:get_host).with('192.148.247.227').and_return('192.148.247.227')
     helper
   }
 
-  let(:create_pod_yml) { File.read('spec/fixtures/output/k8s/expected_pod_create.yml') }
+  let(:pod_yml_from_all_configs) { File.read('spec/fixtures/output/k8s/pod_yml_from_all_configs.yml') }
+  let(:pod_yml_from_defaults) { File.read('spec/fixtures/output/k8s/pod_yml_from_defaults.yml') }
   let(:several_pods) { File.read('spec/fixtures/output/k8s/several_pods.json') }
   let(:single_running_pod) { File.read('spec/fixtures/output/k8s/single_running_pod.json') }
   let(:single_error_pod) { File.read('spec/fixtures/output/k8s/single_error_pod.json') }
@@ -22,6 +24,8 @@ describe OodCore::Job::Adapters::Kubernetes::Batch do
   let(:single_pending_pod) { File.read('spec/fixtures/output/k8s/single_pending_pod.json') }
   let(:single_service) { File.read('spec/fixtures/output/k8s/single_service.json') }
   let(:single_secret) { File.read('spec/fixtures/output/k8s/single_secret.json') }
+  let(:single_secret) { File.read('spec/fixtures/output/k8s/single_secret.json') }
+  let(:ns_prefixed_pod) { File.read('spec/fixtures/output/k8s/ns_prefixed_pod.json') }
 
   let(:now) { DateTime.parse("2020-04-28 20:18:30 +0000") }
   let(:past) { DateTime.parse("2020-04-18 13:01:56 +0000") }
@@ -52,6 +56,8 @@ describe OodCore::Job::Adapters::Kubernetes::Batch do
       cluster: 'test-cluster',
       mounts: mounts,
       all_namespaces: true,
+      namespace_prefix: 'user-',
+      username_prefix: 'dev',
       server: {
         endpoint: 'https://some.k8s.host',
         cert_authority_file: '/etc/some.cert'
@@ -245,6 +251,7 @@ describe OodCore::Job::Adapters::Kubernetes::Batch do
       expect(configured_batch.config_file).to eq('~/kube.config')
       expect(configured_batch.bin).to eq('/usr/bin/wontwork')
       expect(configured_batch.mounts).to eq(mounts)
+      expect(configured_batch.namespace_prefix).to eq('user-')
     end
 
     it "configures correctly configures defaults" do
@@ -271,7 +278,7 @@ describe OodCore::Job::Adapters::Kubernetes::Batch do
       )
     end
 
-    it "submits with correct yml file" do
+    it "submits with correct yml file given all config options" do
       script = build_script(
         accounting_id: 'test',
         native: {
@@ -322,18 +329,83 @@ describe OodCore::Job::Adapters::Kubernetes::Batch do
       # make sure it get's templated right, also helpful in debugging bc
       # it'll show a better diff than the test below.
       template, = configured_batch.send(:generate_id_yml, script)
-      expect(template.to_s).to eql(create_pod_yml.to_s)
+      expect(template.to_s).to eql(pod_yml_from_all_configs.to_s)
 
       # make sure template get's passed into command correctly
       `true`
       allow(Open3).to receive(:capture3).with(
         {},
         "/usr/bin/wontwork --kubeconfig=~/kube.config " \
-        "--namespace=testuser -o json create -f -",
-        stdin_data: create_pod_yml.to_s
+        "--namespace=user-testuser -o json create -f -",
+        stdin_data: pod_yml_from_all_configs.to_s
       ).and_return(['', '', $?])
 
       configured_batch.submit(script)
+    end
+
+    it "submits with correct yml file given default options" do
+      script = build_script(
+        accounting_id: 'test',
+        native: {
+          container: {
+            name: 'rspec-test',
+            image: 'ruby:2.5',
+            command: 'rake spec',
+            port: 8080,
+            env: [
+              {
+                name: 'HOME',
+                value: '/my/home'
+              },
+              {
+                name: 'PATH',
+                value: '/usr/bin:/usr/local/bin'
+              }
+            ],
+            memory: '6Gi',
+            cpu: '4',
+            working_dir: '/my/home',
+            restart_policy: 'Always'
+          },
+          init_containers: [
+            name: 'init-1',
+            image: 'busybox:latest',
+            command: '/bin/ls -lrt .'
+          ],
+          configmap: {
+            filename: 'config.file',
+            data: "a = b\nc = d\n  indentation = keepthis"
+          },
+          mounts: [
+            type: 'host',
+            name: 'ess',
+            host_type: 'Directory',
+            destination_path: '/fs/ess',
+            path: '/fs/ess'
+          ]
+        }
+      )
+
+      allow(@basic_batch).to receive(:generate_id).with('rspec-test').and_return('rspec-test-123')
+      allow(@basic_batch).to receive(:username).and_return('testuser')
+      allow(@basic_batch).to receive(:run_as_user).and_return(1001)
+      allow(@basic_batch).to receive(:run_as_group).and_return(1002)
+
+      # make sure it get's templated right, also helpful in debugging bc
+      # it'll show a better diff than the test below.
+      template, = @basic_batch.send(:generate_id_yml, script)
+      expect(template.to_s).to eql(pod_yml_from_defaults.to_s)
+
+      # make sure template get's passed into command correctly
+      `true`
+      allow(Open3).to receive(:capture3).with(
+        {},
+        "/usr/bin/kubectl --kubeconfig=#{ENV['HOME']}/.kube/config " \
+        "--namespace=testuser -o json create -f -",
+        stdin_data: pod_yml_from_defaults.to_s
+      ).and_return(['', '', $?])
+
+      @basic_batch.submit(script)
     end
   end
 


### PR DESCRIPTION
With #218 we now need to convert map the namespace back to `info.job_owner` because their not necessarily the same any more.

This also fixes #219 though that's kinda secondary.