### PR TITLE
update bundler to v2.1 and update automation to use ruby 2.7

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,18 +15,16 @@ jobs:
     steps:
       - name: checkout
         uses: actions/checkout@v2
-      - uses: actions/setup-ruby@v1
+
+      - name: Setup Ruby using Bundler
+        uses: ruby/setup-ruby@v1
         with:
-          ruby-version: '2.5'
-      - uses: actions/cache@v2
-        with:
-          path: ~/vendor/bundle
-          key: ${{ runner.os }}-gems-${{ hashFiles('Gemfile.lock') }}
-      - name: setup bundler
-        run: |
-          gem install bundler -v 1.17.3
-          bundle config path ~/vendor/bundle
+          ruby-version: "2.7.1"
+          bundler-cache: true
+          bundler: "2.1.4"
+
       - name: install gems
         run: bundle install
+
       - name: test
         run: bundle exec rake spec

--- a/ood_core.gemspec
+++ b/ood_core.gemspec
@@ -24,7 +24,7 @@ Gem::Specification.new do |spec|
 
   spec.add_runtime_dependency "ood_support", "~> 0.0.2"
   spec.add_runtime_dependency "ffi", "~> 1.9", ">= 1.9.6"
-  spec.add_development_dependency "bundler", "~> 1.7"
+  spec.add_development_dependency "bundler", "~> 2.1"
   spec.add_development_dependency "rake", "~> 13.0.1"
   spec.add_development_dependency "rspec", "~> 3.0"
   spec.add_development_dependency "pry", "~> 0.10"


### PR DESCRIPTION
update bundler to v2.1 and update automation to use ruby 2.7.  The GH action also updates to use `ruby/setup-ruby@v1` because it's simpler for a single gem.