### PR TITLE
User preferences

### DIFF
--- a/lib/ood_core/user_preferences.rb
+++ b/lib/ood_core/user_preferences.rb
@@ -2,33 +2,29 @@ module OodCore
   class UserPreferences
     require 'yaml'
 
-    class << self
-
-      def preferences(app: nil, reload: false)
-        app.nil? ? _prefs(reload: reload) : _prefs(reload: reload).fetch(app, {})
-      end
-
-      def preferences_file
+    def preferences_file
+      @preferences_file ||= begin
         pf = ENV['OOD_PREFERENCES_FILE'] || "#{Dir.home}/.config/ondemand/ondemand.yml"
         Pathname.new(pf.to_s).expand_path
       end
+    end
 
-      private
+    def preferences(app: nil)
+      app.nil? ? _prefs : _prefs.fetch(app, {})
+    end
 
-      @_prefs = nil
+    private
 
-      def _prefs(reload: false)
-        return @_prefs if !reload && !@_prefs.nil?
-
-        @@_prefs = begin
-          if preferences_file.file? && preferences_file.readable?
-            YAML.safe_load(preferences_file.read).to_h
-          else
-            {}
-          end
-        rescue
-          @_prefs = {}
+    def _prefs
+      @_prefs ||= begin
+        if preferences_file.file? && preferences_file.readable?
+          YAML.safe_load(preferences_file.read).to_h
+        else
+          {}
         end
+      rescue => e
+        puts "#{e.message}"
+        @_prefs = {}
       end
     end
   end

--- a/lib/ood_core/user_preferences.rb
+++ b/lib/ood_core/user_preferences.rb
@@ -1,0 +1,35 @@
+module OodCore
+  class UserPreferences
+    require 'yaml'
+
+    class << self
+
+      def preferences(app: nil, reload: false)
+        app.nil? ? _prefs(reload: reload) : _prefs(reload: reload).fetch(app, {})
+      end
+
+      def preferences_file
+        pf = ENV['OOD_PREFERENCES_FILE'] || "#{Dir.home}/.config/ondemand/ondemand.yml"
+        Pathname.new(pf.to_s).expand_path
+      end
+
+      private
+
+      @_prefs = nil
+
+      def _prefs(reload: false)
+        return @_prefs if !reload && !@_prefs.nil?
+
+        @@_prefs = begin
+          if preferences_file.file? && preferences_file.readable?
+            YAML.safe_load(preferences_file.read).to_h
+          else
+            {}
+          end
+        rescue
+          @_prefs = {}
+        end
+      end
+    end
+  end
+end

--- a/spec/fixtures/config/preferences/user.yml
+++ b/spec/fixtures/config/preferences/user.yml
@@ -1,0 +1,12 @@
+dashboard:
+  some_thing: 'yesPlease!'
+  show_this: true
+  favorite_apps:
+    - 'one'
+    - 'two'
+    - 'three'
+files:
+  favorite_dirs:
+    - '/home'
+    - '/project'
+    - '/home/ondemand/dev'

--- a/spec/user_preferences_spec.rb
+++ b/spec/user_preferences_spec.rb
@@ -1,0 +1,76 @@
+require "spec_helper"
+require "ood_core/user_preferences"
+
+describe OodCore::UserPreferences do
+
+  let(:preferences_file) { "spec/fixtures/config/preferences/user.yml" }
+
+  let(:old_preferences){{
+    'dashboard' => {
+        'some_thing'    => 'yesPlease!',
+        'show_this'     => false,
+        'favorite_apps' => [ 'one', 'two' ]
+    }
+  }}
+
+  let(:files_preferences){{
+    'favorite_dirs' => ['/home', '/project', '/home/ondemand/dev']
+  }}
+
+  let(:new_preferences){{
+    'dashboard' => {
+        'some_thing'    => 'yesPlease!',
+        'show_this'     => true,
+        'favorite_apps' => ['one', 'two', 'three']
+    },
+    'files' => files_preferences,
+  }}
+
+  describe "#preferences" do
+
+    before(:each) do
+      # nil out preferences before each test
+      OodCore::UserPreferences.instance_variable_set(:@_pref, nil)
+    end
+
+    it "loads preferences" do
+      with_modified_env OOD_PREFERENCES_FILE: preferences_file do
+        prefs = OodCore::UserPreferences.preferences
+        expect(prefs.to_h).to eq(new_preferences)
+      end
+    end
+
+    it "re-loads preferences" do
+      Tempfile.create do |cfgfile|
+        with_modified_env OOD_PREFERENCES_FILE: cfgfile.path do
+          # tmpfile here is trouble to re-write so just close it and use File APIs
+          cfgfile.close
+
+          File.open(cfgfile.path, 'w') { |f| f.write(old_preferences.to_yaml) }
+
+          prefs = OodCore::UserPreferences.preferences(reload: true)
+          expect(prefs.to_h).to eq(old_preferences)
+
+          File.open(cfgfile.path, 'w+') { |f| f.write(new_preferences.to_yaml) }
+
+          prefs = OodCore::UserPreferences.preferences(reload: true)
+          expect(prefs.to_h).to eq(new_preferences)
+        end
+      end
+    end
+
+    it "returns preferences for a single app" do
+      with_modified_env OOD_PREFERENCES_FILE: preferences_file do
+        prefs = OodCore::UserPreferences.preferences(app: 'files')
+        expect(prefs.to_h).to eq(files_preferences)
+      end
+    end
+
+    it "always returns at least an empty hash" do
+      with_modified_env OOD_PREFERENCES_FILE:  "/dev/null" do
+        prefs = OodCore::UserPreferences.preferences
+        expect(prefs.to_h).to eq({})
+      end
+    end
+  end
+end

--- a/spec/user_preferences_spec.rb
+++ b/spec/user_preferences_spec.rb
@@ -28,47 +28,30 @@ describe OodCore::UserPreferences do
 
   describe "#preferences" do
 
-    before(:each) do
-      # nil out preferences before each test
-      OodCore::UserPreferences.instance_variable_set(:@_pref, nil)
-    end
-
     it "loads preferences" do
       with_modified_env OOD_PREFERENCES_FILE: preferences_file do
-        prefs = OodCore::UserPreferences.preferences
+        prefs = OodCore::UserPreferences.new.preferences
         expect(prefs.to_h).to eq(new_preferences)
-      end
-    end
-
-    it "re-loads preferences" do
-      Tempfile.create do |cfgfile|
-        with_modified_env OOD_PREFERENCES_FILE: cfgfile.path do
-          # tmpfile here is trouble to re-write so just close it and use File APIs
-          cfgfile.close
-
-          File.open(cfgfile.path, 'w') { |f| f.write(old_preferences.to_yaml) }
-
-          prefs = OodCore::UserPreferences.preferences(reload: true)
-          expect(prefs.to_h).to eq(old_preferences)
-
-          File.open(cfgfile.path, 'w+') { |f| f.write(new_preferences.to_yaml) }
-
-          prefs = OodCore::UserPreferences.preferences(reload: true)
-          expect(prefs.to_h).to eq(new_preferences)
-        end
       end
     end
 
     it "returns preferences for a single app" do
       with_modified_env OOD_PREFERENCES_FILE: preferences_file do
-        prefs = OodCore::UserPreferences.preferences(app: 'files')
+        prefs = OodCore::UserPreferences.new.preferences(app: 'files')
         expect(prefs.to_h).to eq(files_preferences)
+      end
+    end
+
+    it "returns empty hash for undefined app" do
+      with_modified_env OOD_PREFERENCES_FILE: preferences_file do
+        prefs = OodCore::UserPreferences.new.preferences(app: 'new-app-no-configs')
+        expect(prefs.to_h).to eq({})
       end
     end
 
     it "always returns at least an empty hash" do
       with_modified_env OOD_PREFERENCES_FILE:  "/dev/null" do
-        prefs = OodCore::UserPreferences.preferences
+        prefs = OodCore::UserPreferences.new.preferences
         expect(prefs.to_h).to eq({})
       end
     end


### PR DESCRIPTION
Possible fix for #182

Initially I thought about doing all this stuff statically, so then users can re-load when they want. This could cut down on file reads.  I left the commit here https://github.com/OSC/ood_core/commit/b82a9c0320bda237bfc3c7a92072426566d9363f to view.

But then I thought it's just simpler to read the file when you create the object. That way the upper layers can cache the object and create a new one when they need to reload the configs.