### PR TITLE
k8s templates bugfix

### DIFF
--- a/lib/ood_core/job/adapters/kubernetes/templates/pod.yml.erb
+++ b/lib/ood_core/job/adapters/kubernetes/templates/pod.yml.erb
@@ -80,10 +80,9 @@ spec:
     <%- end # for each mount -%>
   <%- end # init container loop -%>
   <%- end # if init containers -%>
-  <%- unless configmap.nil? || all_mounts.empty? -%>
+  <%- unless (configmap.to_s.empty? && all_mounts.empty?) -%>
   volumes:
-  <%- end # configmap.nil? || all_mounts.empty? -%>
-  <%- unless configmap.nil? -%>
+  <%- unless configmap.to_s.empty? -%>
   - name: configmap-volume
     configMap:
       name: <%= configmap_name(id) %>
@@ -101,6 +100,7 @@ spec:
       type: <%= mount[:host_type] %>
   <%- end # if mount is [host,nfs] -%>
   <%- end # for each mount -%>
+  <%- end # (configmap.to_s.empty? || all_mounts.empty?) -%>
 ---
 <%- unless spec.container.port.nil? -%>
 apiVersion: v1

--- a/spec/fixtures/output/k8s/pod_yml_no_mounts.yml
+++ b/spec/fixtures/output/k8s/pod_yml_no_mounts.yml
@@ -1,0 +1,85 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  namespace: testuser
+  name: rspec-test-123
+  labels:
+    job: rspec-test-123
+    app.kubernetes.io/name: rspec-test
+    app.kubernetes.io/managed-by: open-ondemand
+    account: test
+  annotations:
+spec:
+  restartPolicy: Always
+  securityContext:
+    runAsUser: 1001
+    runAsGroup: 1002
+    fsGroup: 1002
+  containers:
+  - name: "rspec-test"
+    image: ruby:2.5
+    imagePullPolicy: IfNotPresent
+    workingDir: "/my/home"
+    env:
+    - name: HOME
+      value: "/my/home"
+    - name: PATH
+      value: "/usr/bin:/usr/local/bin"
+    command:
+    - "rake"
+    - "spec"
+    ports:
+    - containerPort: 8080
+    volumeMounts:
+    - name: configmap-volume
+      mountPath:  /ood
+    resources:
+      limits:
+        memory: "6Gi"
+        cpu: "4"
+      requests:
+        memory: "6Gi"
+        cpu: "4"
+  initContainers:
+  - name: "init-1"
+    image: "busybox:latest"
+    command:
+    - "/bin/ls"
+    - "-lrt"
+    - "."
+    volumeMounts:
+    - name: configmap-volume
+      mountPath:  /ood
+  volumes:
+  - name: configmap-volume
+    configMap:
+      name: rspec-test-123-configmap
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: rspec-test-123-service
+  namespace: testuser
+  labels:
+    job: rspec-test-123
+spec:
+  selector:
+    job: rspec-test-123
+  ports:
+  - protocol: TCP
+    port: 80
+    targetPort: 8080
+  type: NodePort
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: rspec-test-123-configmap
+  namespace: testuser
+  labels:
+    job: rspec-test-123
+data:
+  config.file: |
+    a = b
+    c = d
+      indentation = keepthis

--- a/spec/job/adapters/kubernetes/batch_spec.rb
+++ b/spec/job/adapters/kubernetes/batch_spec.rb
@@ -16,6 +16,7 @@ describe OodCore::Job::Adapters::Kubernetes::Batch do
 
   let(:pod_yml_from_all_configs) { File.read('spec/fixtures/output/k8s/pod_yml_from_all_configs.yml') }
   let(:pod_yml_from_defaults) { File.read('spec/fixtures/output/k8s/pod_yml_from_defaults.yml') }
+  let(:pod_yml_no_mounts) { File.read('spec/fixtures/output/k8s/pod_yml_no_mounts.yml') }
   let(:several_pods) { File.read('spec/fixtures/output/k8s/several_pods.json') }
   let(:single_running_pod) { File.read('spec/fixtures/output/k8s/single_running_pod.json') }
   let(:single_error_pod) { File.read('spec/fixtures/output/k8s/single_error_pod.json') }
@@ -403,6 +404,64 @@ describe OodCore::Job::Adapters::Kubernetes::Batch do
         "/usr/bin/kubectl --kubeconfig=#{ENV['HOME']}/.kube/config " \
         "--namespace=testuser -o json create -f -",
         stdin_data: pod_yml_from_defaults.to_s
+      ).and_return(['', '', $?])
+
+      @basic_batch.submit(script)
+    end
+
+    it "submits with correct yml file with no mounts" do
+      script = build_script(
+        accounting_id: 'test',
+        native: {
+          container: {
+            name: 'rspec-test',
+            image: 'ruby:2.5',
+            command: 'rake spec',
+            port: 8080,
+            env: [
+              {
+                name: 'HOME',
+                value: '/my/home'
+              },
+              {
+                name: 'PATH',
+                value: '/usr/bin:/usr/local/bin'
+              }
+            ],
+            memory: '6Gi',
+            cpu: '4',
+            working_dir: '/my/home',
+            restart_policy: 'Always'
+          },
+          init_containers: [
+            name: 'init-1',
+            image: 'busybox:latest',
+            command: '/bin/ls -lrt .'
+          ],
+          configmap: {
+            filename: 'config.file',
+            data: "a = b\nc = d\n  indentation = keepthis"
+          },
+        }
+      )
+
+      allow(@basic_batch).to receive(:generate_id).with('rspec-test').and_return('rspec-test-123')
+      allow(@basic_batch).to receive(:username).and_return('testuser')
+      allow(@basic_batch).to receive(:run_as_user).and_return(1001)
+      allow(@basic_batch).to receive(:run_as_group).and_return(1002)
+
+      # make sure it get's templated right, also helpful in debugging bc
+      # it'll show a better diff than the test below.
+      template, = @basic_batch.send(:generate_id_yml, script)
+      expect(template.to_s).to eql(pod_yml_no_mounts.to_s)
+
+      # make sure template get's passed into command correctly
+      `true`
+      allow(Open3).to receive(:capture3).with(
+        {},
+        "/usr/bin/kubectl --kubeconfig=#{ENV['HOME']}/.kube/config " \
+        "--namespace=testuser -o json create -f -",
+        stdin_data: pod_yml_no_mounts.to_s
       ).and_return(['', '', $?])
 
       @basic_batch.submit(script)


### PR DESCRIPTION
I found this in AKS testing that the k8s pod template did not correctly populate a 'volumes' section when there are no mounts present.  One only has to checkout the master version of `lib/ood_core/job/adapters/kubernetes/templates/pod.yml.erb` and run this added test to verify.