### PR TITLE
use the semi-full module path for classes

### DIFF
--- a/lib/ood_core/job/adapters/kubernetes/batch.rb
+++ b/lib/ood_core/job/adapters/kubernetes/batch.rb
@@ -6,10 +6,6 @@ class OodCore::Job::Adapters::Kubernetes::Batch
   require_relative "helper"
   require_relative "k8s_job_info"
 
-  Helper = OodCore::Job::Adapters::Kubernetes::Helper
-  Resources = OodCore::Job::Adapters::Kubernetes::Resources
-  K8sJobInfo = OodCore::Job::Adapters::Kubernetes::K8sJobInfo
-
   using OodCore::Refinements::HashExtensions
 
   class Error < StandardError; end
@@ -177,7 +173,7 @@ class OodCore::Job::Adapters::Kubernetes::Batch
     id = generate_id(container.name)
     configmap = helper.configmap_from_native(native_data, id)
     init_containers = helper.init_ctrs_from_native(native_data[:init_containers])
-    spec = Resources::PodSpec.new(container, init_containers: init_containers)
+    spec = Kubernetes::Resources::PodSpec.new(container, init_containers: init_containers)
     all_mounts = native_data[:mounts].nil? ? mounts : mounts + native_data[:mounts]
 
     template = ERB.new(File.read(resource_file), nil, '-')

--- a/lib/ood_core/job/adapters/kubernetes/helper.rb
+++ b/lib/ood_core/job/adapters/kubernetes/helper.rb
@@ -8,9 +8,6 @@ class OodCore::Job::Adapters::Kubernetes::Helper
 
   class K8sDataError < StandardError; end
 
-  Resources = OodCore::Job::Adapters::Kubernetes::Resources
-  K8sJobInfo = OodCore::Job::Adapters::Kubernetes::K8sJobInfo
-
   # Extract info from json data. The data is expected to be from the kubectl
   # command and conform to kubernetes' datatype structures.
   #
@@ -43,7 +40,7 @@ class OodCore::Job::Adapters::Kubernetes::Helper
   #   the input container hash
   # @return  [OodCore::Job::Adapters::Kubernetes::Resources::Container]
   def container_from_native(container)
-    Resources::Container.new(
+    Kubernetes::Resources::Container.new(
       container[:name],
       container[:image],
       command: parse_command(container[:command]),
@@ -84,7 +81,7 @@ class OodCore::Job::Adapters::Kubernetes::Helper
     configmap = native.fetch(:configmap, nil)
     return nil if configmap.nil?
 
-    Resources::ConfigMap.new(
+    Kubernetes::Resources::ConfigMap.new(
       configmap_name(id),
       configmap[:filename],
       configmap[:data]


### PR DESCRIPTION
This came up in #222 I just didn't get a chance to add it there, so it's here.

This references classes with the semi-full module path instead of redefining them.