### PR TITLE
use full module names in k8s helper classes

### DIFF
--- a/lib/ood_core/job/adapters/kubernetes/batch.rb
+++ b/lib/ood_core/job/adapters/kubernetes/batch.rb
@@ -27,7 +27,7 @@ class OodCore::Job::Adapters::Kubernetes::Batch
     @namespace_prefix = options.fetch(:namespace_prefix, '')
 
     @using_context = false
-    @helper = Helper.new
+    @helper = OodCore::Job::Adapters::Kubernetes::Helper.new
 
     begin
       make_kubectl_config(options)
@@ -173,7 +173,7 @@ class OodCore::Job::Adapters::Kubernetes::Batch
     id = generate_id(container.name)
     configmap = helper.configmap_from_native(native_data, id)
     init_containers = helper.init_ctrs_from_native(native_data[:init_containers])
-    spec = Kubernetes::Resources::PodSpec.new(container, init_containers: init_containers)
+    spec = OodCore::Job::Adapters::Kubernetes::Resources::PodSpec.new(container, init_containers: init_containers)
     all_mounts = native_data[:mounts].nil? ? mounts : mounts + native_data[:mounts]
 
     template = ERB.new(File.read(resource_file), nil, '-')

--- a/lib/ood_core/job/adapters/kubernetes/helper.rb
+++ b/lib/ood_core/job/adapters/kubernetes/helper.rb
@@ -29,7 +29,7 @@ class OodCore::Job::Adapters::Kubernetes::Helper
 
     pod_hash.deep_merge!(service_hash)
     pod_hash.deep_merge!(secret_hash)
-    K8sJobInfo.new(pod_hash)
+    OodCore::Job::Adapters::Kubernetes::K8sJobInfo.new(pod_hash)
   rescue NoMethodError
     raise K8sDataError, "unable to read data correctly from json"
   end
@@ -40,7 +40,7 @@ class OodCore::Job::Adapters::Kubernetes::Helper
   #   the input container hash
   # @return  [OodCore::Job::Adapters::Kubernetes::Resources::Container]
   def container_from_native(container)
-    Kubernetes::Resources::Container.new(
+    OodCore::Job::Adapters::Kubernetes::Resources::Container.new(
       container[:name],
       container[:image],
       command: parse_command(container[:command]),
@@ -81,7 +81,7 @@ class OodCore::Job::Adapters::Kubernetes::Helper
     configmap = native.fetch(:configmap, nil)
     return nil if configmap.nil?
 
-    Kubernetes::Resources::ConfigMap.new(
+    OodCore::Job::Adapters::Kubernetes::Resources::ConfigMap.new(
       configmap_name(id),
       configmap[:filename],
       configmap[:data]


### PR DESCRIPTION
K8s is currently broken with all sorts of uninitialized constant errors.  So the fix is just to directly use the full module::class name to reference objects.