### PR TITLE
Improved Kubernetes pod security

### DIFF
--- a/lib/ood_core/job/adapters/kubernetes/resources.rb
+++ b/lib/ood_core/job/adapters/kubernetes/resources.rb
@@ -12,11 +12,11 @@ module OodCore::Job::Adapters::Kubernetes::Resources
 
   class Container
     attr_accessor :name, :image, :command, :port, :env, :memory, :cpu, :working_dir,
-                  :restart_policy
+                  :restart_policy, :supplemental_groups
 
     def initialize(
         name, image, command: [], port: nil, env: [], memory: "4Gi", cpu: "1",
-        working_dir: "", restart_policy: "Never"
+        working_dir: "", restart_policy: "Never", supplemental_groups: []
       )
       raise ArgumentError, "containers need valid names and images" unless name && image
 
@@ -29,6 +29,7 @@ module OodCore::Job::Adapters::Kubernetes::Resources
       @cpu = cpu.nil? ? "1" : cpu
       @working_dir = working_dir.nil? ? "" : working_dir
       @restart_policy = restart_policy.nil? ? "Never" : restart_policy
+      @supplemental_groups = supplemental_groups.nil? ? [] : supplemental_groups
     end
 
     def ==(other)
@@ -40,7 +41,8 @@ module OodCore::Job::Adapters::Kubernetes::Resources
         memory == other.memory &&
         cpu == other.cpu &&
         working_dir == other.working_dir &&
-        restart_policy == other.restart_policy
+        restart_policy == other.restart_policy &&
+        supplemental_groups == other.supplemental_groups
     end
 
   end

--- a/lib/ood_core/job/adapters/kubernetes/templates/pod.yml.erb
+++ b/lib/ood_core/job/adapters/kubernetes/templates/pod.yml.erb
@@ -19,7 +19,18 @@ spec:
   securityContext:
     runAsUser: <%= run_as_user %>
     runAsGroup: <%= run_as_group %>
+    <%- if spec.container.supplemental_groups.empty? -%>
+    supplementalGroups: []
+    <%- else -%>
+    supplementalGroups:
+    <%- spec.container.supplemental_groups.each do |supplemental_group| -%>
+    - "<%= supplemental_group %>"
+    <%- end -%>
+    <%- end -%>
     fsGroup: <%= fs_group %>
+  hostNetwork: false
+  hostIPC: false
+  hostPID: false
   containers:
   - name: "<%= spec.container.name %>"
     image: <%= spec.container.image %>
@@ -60,6 +71,12 @@ spec:
       requests:
         memory: "<%= spec.container.memory %>"
         cpu: "<%= spec.container.cpu %>"
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - all
+      privileged: false
   <%- unless spec.init_containers.nil? -%>
   initContainers:
   <%- spec.init_containers.each do |ctr| -%>
@@ -78,6 +95,12 @@ spec:
     - name: <%= mount[:name] %>
       mountPath: <%= mount[:destination_path] %>
     <%- end # for each mount -%>
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - all
+      privileged: false
   <%- end # init container loop -%>
   <%- end # if init containers -%>
   <%- unless (configmap.to_s.empty? && all_mounts.empty?) -%>

--- a/spec/fixtures/output/k8s/pod_yml_from_all_configs.yml
+++ b/spec/fixtures/output/k8s/pod_yml_from_all_configs.yml
@@ -14,7 +14,11 @@ spec:
   securityContext:
     runAsUser: 1001
     runAsGroup: 1002
+    supplementalGroups: []
     fsGroup: 1002
+  hostNetwork: false
+  hostIPC: false
+  hostPID: false
   containers:
   - name: "rspec-test"
     image: ruby:2.5
@@ -46,6 +50,12 @@ spec:
       requests:
         memory: "6Gi"
         cpu: "4"
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - all
+      privileged: false
   initContainers:
   - name: "init-1"
     image: "busybox:latest"
@@ -62,6 +72,12 @@ spec:
       mountPath: /fs
     - name: ess
       mountPath: /fs/ess
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - all
+      privileged: false
   volumes:
   - name: configmap-volume
     configMap:

--- a/spec/fixtures/output/k8s/pod_yml_from_defaults.yml
+++ b/spec/fixtures/output/k8s/pod_yml_from_defaults.yml
@@ -14,7 +14,11 @@ spec:
   securityContext:
     runAsUser: 1001
     runAsGroup: 1002
+    supplementalGroups: []
     fsGroup: 1002
+  hostNetwork: false
+  hostIPC: false
+  hostPID: false
   containers:
   - name: "rspec-test"
     image: ruby:2.5
@@ -42,6 +46,12 @@ spec:
       requests:
         memory: "6Gi"
         cpu: "4"
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - all
+      privileged: false
   initContainers:
   - name: "init-1"
     image: "busybox:latest"
@@ -54,6 +64,12 @@ spec:
       mountPath:  /ood
     - name: ess
       mountPath: /fs/ess
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - all
+      privileged: false
   volumes:
   - name: configmap-volume
     configMap:

--- a/spec/fixtures/output/k8s/pod_yml_no_mounts.yml
+++ b/spec/fixtures/output/k8s/pod_yml_no_mounts.yml
@@ -14,7 +14,11 @@ spec:
   securityContext:
     runAsUser: 1001
     runAsGroup: 1002
+    supplementalGroups: []
     fsGroup: 1002
+  hostNetwork: false
+  hostIPC: false
+  hostPID: false
   containers:
   - name: "rspec-test"
     image: ruby:2.5
@@ -40,6 +44,12 @@ spec:
       requests:
         memory: "6Gi"
         cpu: "4"
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - all
+      privileged: false
   initContainers:
   - name: "init-1"
     image: "busybox:latest"
@@ -50,6 +60,12 @@ spec:
     volumeMounts:
     - name: configmap-volume
       mountPath:  /ood
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - all
+      privileged: false
   volumes:
   - name: configmap-volume
     configMap:


### PR DESCRIPTION
Ensure the Pod YAML has proper security defined in case sites don't use Pod Security Policies or other tools to enforce stricter security.  For OSC these things will be enforced using Kyverno but sites can choose whatever tool they wish to enforce these values are set.  This helps ensure OnDemand is shipping with "secure by default" settings.