### PR TITLE
Also add runAsNonRoot to K8 pod

### DIFF
--- a/lib/ood_core/job/adapters/kubernetes/templates/pod.yml.erb
+++ b/lib/ood_core/job/adapters/kubernetes/templates/pod.yml.erb
@@ -19,6 +19,7 @@ spec:
   securityContext:
     runAsUser: <%= run_as_user %>
     runAsGroup: <%= run_as_group %>
+    runAsNonRoot: true
     <%- if spec.container.supplemental_groups.empty? -%>
     supplementalGroups: []
     <%- else -%>

--- a/spec/fixtures/output/k8s/pod_yml_from_all_configs.yml
+++ b/spec/fixtures/output/k8s/pod_yml_from_all_configs.yml
@@ -14,6 +14,7 @@ spec:
   securityContext:
     runAsUser: 1001
     runAsGroup: 1002
+    runAsNonRoot: true
     supplementalGroups: []
     fsGroup: 1002
   hostNetwork: false

--- a/spec/fixtures/output/k8s/pod_yml_from_defaults.yml
+++ b/spec/fixtures/output/k8s/pod_yml_from_defaults.yml
@@ -14,6 +14,7 @@ spec:
   securityContext:
     runAsUser: 1001
     runAsGroup: 1002
+    runAsNonRoot: true
     supplementalGroups: []
     fsGroup: 1002
   hostNetwork: false

--- a/spec/fixtures/output/k8s/pod_yml_no_mounts.yml
+++ b/spec/fixtures/output/k8s/pod_yml_no_mounts.yml
@@ -14,6 +14,7 @@ spec:
   securityContext:
     runAsUser: 1001
     runAsGroup: 1002
+    runAsNonRoot: true
     supplementalGroups: []
     fsGroup: 1002
   hostNetwork: false


### PR DESCRIPTION
Saw many community Pods and some best practice docs to also set this. Also the Kyverno policies we will apply at OSC will enforce this even if `runAsUser` is set. I'm not 100% certain if `runAsNonRoot` is useless when setting `runAsUser` but figured doesn't hurt to define both.