### PR TITLE
Make K8 configmap configuration more intuitive

### DIFF
--- a/lib/ood_core/job/adapters/kubernetes/batch.rb
+++ b/lib/ood_core/job/adapters/kubernetes/batch.rb
@@ -112,10 +112,6 @@ class OodCore::Job::Adapters::Kubernetes::Batch
     safe_call("delete", "configmap", configmap_name(id))
   end
 
-  def configmap_mount_path
-    '/ood'
-  end
-
   private
 
   def safe_call(verb, resource, id)

--- a/lib/ood_core/job/adapters/kubernetes/resources.rb
+++ b/lib/ood_core/job/adapters/kubernetes/resources.rb
@@ -10,6 +10,14 @@ module OodCore::Job::Adapters::Kubernetes::Resources
         @files << ConfigMapFile.new(f)
       end
     end
+
+    def mounts?
+      @files.any? { |f| f.mount_path }
+    end
+
+    def init_mounts?
+      @files.any? { |f| f.init_mount_path }
+    end
   end
 
   class ConfigMapFile

--- a/lib/ood_core/job/adapters/kubernetes/templates/pod.yml.erb
+++ b/lib/ood_core/job/adapters/kubernetes/templates/pod.yml.erb
@@ -58,20 +58,21 @@ spec:
     ports:
     - containerPort: <%= spec.container.port %>
     <%- end -%>
+    <%- if configmap.mounts? || !all_mounts.empty? -%>
     volumeMounts:
-    <%- unless configmap.nil? -%>
     <%- configmap.files.each do |file| -%>
+      <%- next if file.mount_path.nil? -%>
     - name: configmap-volume
-      mountPath: <%= file.mount_path || configmap_mount_path %>
+      mountPath: <%= file.mount_path %>
       <%- unless file.sub_path.nil? -%>
       subPath: <%= file.sub_path %>
       <%- end # end unless file.sub_path.nil? -%>
-    <%- end # end configmap.data.each -%>
-    <%- end # unless configmap -%>
+    <%- end # end configmap.files.each -%>
     <%- all_mounts.each do |mount| -%>
     - name: <%= mount[:name] %>
       mountPath: <%= mount[:destination_path] %>
     <%- end # for each mount -%>
+    <%- end # configmap mounts? and all_mounts not empty -%>
     resources:
       limits:
         memory: "<%= spec.container.memory %>"
@@ -103,21 +104,21 @@ spec:
     <%- ctr.command.each do |cmd| -%>
     - "<%= cmd %>"
     <%- end # command loop -%>
+    <%- if configmap.init_mounts? || !all_mounts.empty? -%>
     volumeMounts:
-    <%- unless configmap.nil? -%>
     <%- configmap.files.each do |file| -%>
-    <%- next if file.init_mount_path == false -%>
+    <%- next if file.init_mount_path.nil? -%>
     - name: configmap-volume
-      mountPath: <%= file.init_mount_path || configmap_mount_path %>
+      mountPath: <%= file.init_mount_path %>
       <%- unless file.init_sub_path.nil? -%>
       subPath: <%= file.init_sub_path %>
       <%- end # end unless file.sub_path.nil? -%>
-    <%- end # end configmap.data.each -%>
-    <%- end # unless configmap -%>
+    <%- end # end configmap.files.each -%>
     <%- all_mounts.each do |mount| -%>
     - name: <%= mount[:name] %>
       mountPath: <%= mount[:destination_path] %>
     <%- end # for each mount -%>
+    <%- end # if config_map init mounts and all_mounts not empty -%>
     securityContext:
       allowPrivilegeEscalation: false
       capabilities:

--- a/spec/fixtures/output/k8s/pod_yml_from_defaults.yml
+++ b/spec/fixtures/output/k8s/pod_yml_from_defaults.yml
@@ -90,8 +90,6 @@ spec:
     - "-lrt"
     - "."
     volumeMounts:
-    - name: configmap-volume
-      mountPath: /ood
     - name: ess
       mountPath: /fs/ess
     securityContext:

--- a/spec/fixtures/output/k8s/pod_yml_no_mounts.yml
+++ b/spec/fixtures/output/k8s/pod_yml_no_mounts.yml
@@ -47,9 +47,6 @@ spec:
     - "spec"
     ports:
     - containerPort: 8080
-    volumeMounts:
-    - name: configmap-volume
-      mountPath: /ood
     resources:
       limits:
         memory: "6Gi"
@@ -87,9 +84,6 @@ spec:
     - "/bin/ls"
     - "-lrt"
     - "."
-    volumeMounts:
-    - name: configmap-volume
-      mountPath: /ood
     securityContext:
       allowPrivilegeEscalation: false
       capabilities:

--- a/spec/fixtures/output/k8s/pod_yml_no_mounts_no_configmaps.yml
+++ b/spec/fixtures/output/k8s/pod_yml_no_mounts_no_configmaps.yml
@@ -47,9 +47,6 @@ spec:
     - "spec"
     ports:
     - containerPort: 8080
-    volumeMounts:
-    - name: configmap-volume
-      mountPath: /ood
     resources:
       limits:
         memory: "6Gi"

--- a/spec/job/adapters/kubernetes/batch_spec.rb
+++ b/spec/job/adapters/kubernetes/batch_spec.rb
@@ -20,6 +20,7 @@ describe OodCore::Job::Adapters::Kubernetes::Batch do
   let(:pod_yml_from_defaults) { File.read('spec/fixtures/output/k8s/pod_yml_from_defaults.yml') }
   let(:pod_yml_no_mounts) { File.read('spec/fixtures/output/k8s/pod_yml_no_mounts.yml') }
   let(:pod_yml_subpath_configmap) { File.read('spec/fixtures/output/k8s/pod_yml_subpath_configmap.yml') }
+  let(:pod_yml_no_mounts_no_configmaps) { File.read('spec/fixtures/output/k8s/pod_yml_no_mounts_no_configmaps.yml') }
   let(:several_pods) { File.read('spec/fixtures/output/k8s/several_pods.json') }
   let(:single_running_pod) { File.read('spec/fixtures/output/k8s/single_running_pod.json') }
   let(:single_error_pod) { File.read('spec/fixtures/output/k8s/single_error_pod.json') }
@@ -416,7 +417,8 @@ describe OodCore::Job::Adapters::Kubernetes::Batch do
           configmap: {
             files: [{
               filename: 'config.file',
-              data: "a = b\nc = d\n  indentation = keepthis"
+              data: "a = b\nc = d\n  indentation = keepthis",
+              mount_path: '/ood'
             }],
           },
         }
@@ -508,6 +510,59 @@ describe OodCore::Job::Adapters::Kubernetes::Batch do
         "/usr/bin/kubectl --kubeconfig=#{ENV['HOME']}/.kube/config " \
         "--namespace=testuser -o json create -f -",
         stdin_data: pod_yml_subpath_configmap.to_s
+      ).and_return(['', '', $?])
+
+      @basic_batch.submit(script)
+    end
+
+    it "submits with correct yml file with no mounts no configmap mounts" do
+      script = build_script(
+        accounting_id: 'test',
+        native: {
+          container: {
+            name: 'rspec-test',
+            image: 'ruby:2.5',
+            command: 'rake spec',
+            port: 8080,
+            env: {
+              PATH: '/usr/bin:/usr/local/bin'
+            },
+            memory: '6Gi',
+            cpu: '4',
+            working_dir: '/my/home',
+            restart_policy: 'Always'
+          },
+          init_containers: [
+            name: 'init-1',
+            image: 'busybox:latest',
+            command: '/bin/ls -lrt .'
+          ],
+          configmap: {
+            files: [{
+              filename: 'config.file',
+              data: "a = b\nc = d\n  indentation = keepthis",
+            }],
+          },
+        }
+      )
+
+      allow(@basic_batch).to receive(:generate_id).with('rspec-test').and_return('rspec-test-123')
+      allow(@basic_batch).to receive(:username).and_return('testuser')
+      allow(@basic_batch).to receive(:user).and_return(User.new(dir: '/home/testuser', uid: 1001, gid: 1002))
+      allow(@basic_batch).to receive(:group).and_return('testgroup')
+
+      # make sure it get's templated right, also helpful in debugging bc
+      # it'll show a better diff than the test below.
+      template, = @basic_batch.send(:generate_id_yml, script)
+      expect(template.to_s).to eql(pod_yml_no_mounts_no_configmaps.to_s)
+
+      # make sure template get's passed into command correctly
+      `true`
+      allow(Open3).to receive(:capture3).with(
+        {},
+        "/usr/bin/kubectl --kubeconfig=#{ENV['HOME']}/.kube/config " \
+        "--namespace=testuser -o json create -f -",
+        stdin_data: pod_yml_no_mounts_no_configmaps.to_s
       ).and_return(['', '', $?])
 
       @basic_batch.submit(script)

--- a/spec/job/adapters/kubernetes/batch_spec.rb
+++ b/spec/job/adapters/kubernetes/batch_spec.rb
@@ -294,7 +294,9 @@ describe OodCore::Job::Adapters::Kubernetes::Batch do
           configmap: {
             files: [{
               filename: 'config.file',
-              data: "a = b\nc = d\n  indentation = keepthis"
+              data: "a = b\nc = d\n  indentation = keepthis",
+              mount_path: '/ood',
+              init_mount_path: '/ood'
             }],
           },
           mounts: [
@@ -354,7 +356,8 @@ describe OodCore::Job::Adapters::Kubernetes::Batch do
           configmap: {
             files: [{
               filename: 'config.file',
-              data: "a = b\nc = d\n  indentation = keepthis"
+              data: "a = b\nc = d\n  indentation = keepthis",
+              mount_path: '/ood'
             }],
           },
           mounts: [
@@ -468,7 +471,9 @@ describe OodCore::Job::Adapters::Kubernetes::Batch do
             files: [
               {
                 filename: 'config.file',
-                data: "a = b\nc = d\n  indentation = keepthis"
+                data: "a = b\nc = d\n  indentation = keepthis",
+                mount_path: '/ood',
+                init_mount_path: '/ood'
               },
               {
                 filename: 'passwd',
@@ -480,7 +485,6 @@ describe OodCore::Job::Adapters::Kubernetes::Batch do
                 filename: 'group',
                 mount_path: '/etc/group',
                 sub_path: 'group',
-                init_mount_path: false
               }
             ],
           },


### PR DESCRIPTION
Fixes #254 

I opted so that the init configmap mount only happens when you define `init_mount_path`, same for main container and `mount_path`.