### PR TITLE
interpret tmux 1.8 and 2.7 error messages

### DIFF
--- a/spec/job/adapters/linux_host/launcher_spec.rb
+++ b/spec/job/adapters/linux_host/launcher_spec.rb
@@ -109,16 +109,14 @@ describe OodCore::Job::Adapters::LinuxHost::Launcher do
 
     describe "#stop_remote_session" do
         context "when the tmux server is not running" do
-            it "does not raise an error" do
+            it "does not raise an error for 1.8 messages" do
                 allow(Open3).to receive(:capture3).and_return(['remote_host', 'failed to connect to server', exit_failure])
 
                 subject.stop_remote_session('job', 'remote_host')
             end
-        end
 
-        context "when the tmux session name is not found" do
-            it "does not raise an error" do
-                allow(Open3).to receive(:capture3).and_return(['remote_host', "session not found: #{subject.session_name_label}", exit_failure])
+            it "does not raise an error for 2.7 messages" do
+                allow(Open3).to receive(:capture3).and_return(['remote_host', 'no server running on /tmp/tmux-30961/default', exit_failure])
 
                 subject.stop_remote_session('job', 'remote_host')
             end


### PR DESCRIPTION
tmux error messages changed at some point in 2.x. This was confirmed in 2.7 (what ships with centos/rhel 8). This also removes a test case and error message that's no longer valid. We don't use the tmux 'has-session' api anywhere and therefore should not check for it's error messages.

While #258 fixes an issue found with 2.7, this updates so that we can interpret 2.7's error messages as well.