### PR TITLE
Allow K8 pods to select a specific compute cluster

### DIFF
--- a/lib/ood_core/job/adapters/kubernetes/batch.rb
+++ b/lib/ood_core/job/adapters/kubernetes/batch.rb
@@ -193,6 +193,7 @@ class OodCore::Job::Adapters::Kubernetes::Batch
     init_containers = helper.init_ctrs_from_native(native_data[:init_containers], container.env)
     spec = OodCore::Job::Adapters::Kubernetes::Resources::PodSpec.new(container, init_containers: init_containers)
     all_mounts = native_data[:mounts].nil? ? mounts : mounts + native_data[:mounts]
+    cluster = native_data[:cluster]
 
     template = ERB.new(File.read(resource_file), nil, '-')
 

--- a/lib/ood_core/job/adapters/kubernetes/templates/pod.yml.erb
+++ b/lib/ood_core/job/adapters/kubernetes/templates/pod.yml.erb
@@ -148,6 +148,10 @@ spec:
   <%- end # if mount is [host,nfs] -%>
   <%- end # for each mount -%>
   <%- end # (configmap.to_s.empty? || all_mounts.empty?) -%>
+  <%- unless cluster.nil? -%>
+  nodeSelector:
+    cluster: <%= cluster %>
+  <%- end -%>
 ---
 <%- unless spec.container.port.nil? -%>
 apiVersion: v1

--- a/spec/fixtures/output/k8s/pod_yml_with_cluster.yml
+++ b/spec/fixtures/output/k8s/pod_yml_with_cluster.yml
@@ -1,0 +1,139 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  namespace: testuser
+  name: rspec-test-123
+  labels:
+    job: rspec-test-123
+    app.kubernetes.io/name: rspec-test
+    app.kubernetes.io/managed-by: open-ondemand
+    account: test
+  annotations:
+spec:
+  restartPolicy: Always
+  securityContext:
+    runAsUser: 1001
+    runAsGroup: 1002
+    runAsNonRoot: true
+    supplementalGroups: []
+    fsGroup: 1002
+  hostNetwork: false
+  hostIPC: false
+  hostPID: false
+  containers:
+  - name: "rspec-test"
+    image: ruby:2.5
+    imagePullPolicy: IfNotPresent
+    workingDir: "/my/home"
+    env:
+    - name: POD_NAME
+      valueFrom:
+        fieldRef:
+          fieldPath: metadata.name
+    - name: USER
+      value: "testuser"
+    - name: UID
+      value: "1001"
+    - name: HOME
+      value: "/my/home"
+    - name: GROUP
+      value: "testgroup"
+    - name: GID
+      value: "1002"
+    - name: PATH
+      value: "/usr/bin:/usr/local/bin"
+    command:
+    - "rake"
+    - "spec"
+    ports:
+    - containerPort: 8080
+    volumeMounts:
+    - name: configmap-volume
+      mountPath: /ood
+    - name: ess
+      mountPath: /fs/ess
+    resources:
+      limits:
+        memory: "6Gi"
+        cpu: "4"
+      requests:
+        memory: "6Gi"
+        cpu: "4"
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - all
+      privileged: false
+  initContainers:
+  - name: "init-1"
+    image: "busybox:latest"
+    env:
+    - name: POD_NAME
+      valueFrom:
+        fieldRef:
+          fieldPath: metadata.name
+    - name: USER
+      value: "testuser"
+    - name: UID
+      value: "1001"
+    - name: HOME
+      value: "/my/home"
+    - name: GROUP
+      value: "testgroup"
+    - name: GID
+      value: "1002"
+    - name: PATH
+      value: "/usr/bin:/usr/local/bin"
+    command:
+    - "/bin/ls"
+    - "-lrt"
+    - "."
+    volumeMounts:
+    - name: ess
+      mountPath: /fs/ess
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - all
+      privileged: false
+  volumes:
+  - name: configmap-volume
+    configMap:
+      name: rspec-test-123-configmap
+  - name: ess
+    hostPath:
+      path: /fs/ess
+      type: Directory
+  nodeSelector:
+    cluster: test
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: rspec-test-123-service
+  namespace: testuser
+  labels:
+    job: rspec-test-123
+spec:
+  selector:
+    job: rspec-test-123
+  ports:
+  - protocol: TCP
+    port: 80
+    targetPort: 8080
+  type: NodePort
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: rspec-test-123-configmap
+  namespace: testuser
+  labels:
+    job: rspec-test-123
+data:
+  config.file: |
+    a = b
+    c = d
+      indentation = keepthis

--- a/spec/job/adapters/kubernetes/batch_spec.rb
+++ b/spec/job/adapters/kubernetes/batch_spec.rb
@@ -21,6 +21,7 @@ describe OodCore::Job::Adapters::Kubernetes::Batch do
   let(:pod_yml_no_mounts) { File.read('spec/fixtures/output/k8s/pod_yml_no_mounts.yml') }
   let(:pod_yml_subpath_configmap) { File.read('spec/fixtures/output/k8s/pod_yml_subpath_configmap.yml') }
   let(:pod_yml_no_mounts_no_configmaps) { File.read('spec/fixtures/output/k8s/pod_yml_no_mounts_no_configmaps.yml') }
+  let(:pod_yml_with_cluster) { File.read('spec/fixtures/output/k8s/pod_yml_with_cluster.yml') }
   let(:several_pods) { File.read('spec/fixtures/output/k8s/several_pods.json') }
   let(:single_running_pod) { File.read('spec/fixtures/output/k8s/single_running_pod.json') }
   let(:single_error_pod) { File.read('spec/fixtures/output/k8s/single_error_pod.json') }
@@ -564,6 +565,68 @@ describe OodCore::Job::Adapters::Kubernetes::Batch do
         "--namespace=testuser -o json create -f -",
         stdin_data: pod_yml_no_mounts_no_configmaps.to_s
       ).and_return(['', '', $?])
+
+      @basic_batch.submit(script)
+    end
+
+    it "submits with correct yml file requesting a cluster" do
+      script = build_script(
+        accounting_id: 'test',
+        native: {
+          container: {
+            name: 'rspec-test',
+            image: 'ruby:2.5',
+            command: 'rake spec',
+            port: 8080,
+            env: {
+              'HOME' => '/my/home',
+              'PATH' => '/usr/bin:/usr/local/bin'
+            },
+            memory: '6Gi',
+            cpu: '4',
+            working_dir: '/my/home',
+            restart_policy: 'Always'
+          },
+          init_containers: [
+            name: 'init-1',
+            image: 'busybox:latest',
+            command: '/bin/ls -lrt .'
+          ],
+          configmap: {
+            files: [{
+              filename: 'config.file',
+              data: "a = b\nc = d\n  indentation = keepthis",
+              mount_path: '/ood'
+            }],
+          },
+          mounts: [
+            type: 'host',
+            name: 'ess',
+            host_type: 'Directory',
+            destination_path: '/fs/ess',
+            path: '/fs/ess'
+          ],
+          cluster: 'test'
+        }
+      )
+
+      allow(@basic_batch).to receive(:generate_id).with('rspec-test').and_return('rspec-test-123')
+      allow(@basic_batch).to receive(:username).and_return('testuser')
+      allow(@basic_batch).to receive(:user).and_return(User.new(dir: '/home/testuser', uid: 1001, gid: 1002))
+      allow(@basic_batch).to receive(:group).and_return('testgroup')
+
+      # make sure it get's templated right, also helpful in debugging bc
+      # it'll show a better diff than the test below.
+      template, = @basic_batch.send(:generate_id_yml, script)
+      expect(template.to_s).to eql(pod_yml_with_cluster.to_s)
+
+      # make sure template get's passed into command correctly
+      allow(Open3).to receive(:capture3).with(
+        {},
+        "/usr/bin/kubectl --kubeconfig=#{ENV['HOME']}/.kube/config " \
+        "--namespace=testuser -o json create -f -",
+        stdin_data: pod_yml_with_cluster.to_s
+      ).and_return(['', '', success])
 
       @basic_batch.submit(script)
     end


### PR DESCRIPTION
The K8 environment at OSC will have some worker nodes with `cluster=pitzer` from that compute environment and some with `cluster=owens`.  It's highly likely they will have differences if nothing else than the hardware.  If we don't care about the hardware a user can request then this pull request serves no purpose.  For things like /apps and /usr/local I think what we'd do is mount pitzers /apps to /apps/pitzer and owens to /apps/owens, we can't mount things to /usr/local.