### PR TITLE
Allow K8 pods to use nodeSelector

### DIFF
--- a/lib/ood_core/job/adapters/kubernetes/batch.rb
+++ b/lib/ood_core/job/adapters/kubernetes/batch.rb
@@ -193,6 +193,7 @@ class OodCore::Job::Adapters::Kubernetes::Batch
     init_containers = helper.init_ctrs_from_native(native_data[:init_containers], container.env)
     spec = OodCore::Job::Adapters::Kubernetes::Resources::PodSpec.new(container, init_containers: init_containers)
     all_mounts = native_data[:mounts].nil? ? mounts : mounts + native_data[:mounts]
+    node_selector = native_data[:node_selector].nil? ? {} : native_data[:node_selector]
 
     template = ERB.new(File.read(resource_file), nil, '-')
 

--- a/lib/ood_core/job/adapters/kubernetes/templates/pod.yml.erb
+++ b/lib/ood_core/job/adapters/kubernetes/templates/pod.yml.erb
@@ -148,6 +148,12 @@ spec:
   <%- end # if mount is [host,nfs] -%>
   <%- end # for each mount -%>
   <%- end # (configmap.to_s.empty? || all_mounts.empty?) -%>
+  <%- unless node_selector.empty? -%>
+  nodeSelector:
+  <%- node_selector.each_pair do |key, value| -%>
+    <%= key %>: "<%= value %>"
+  <%- end # node_selector.each_pair -%>
+  <%- end #unless node_selector.empty? -%>
 ---
 <%- unless spec.container.port.nil? -%>
 apiVersion: v1

--- a/spec/fixtures/output/k8s/pod_yml_from_all_configs.yml
+++ b/spec/fixtures/output/k8s/pod_yml_from_all_configs.yml
@@ -124,6 +124,8 @@ spec:
     hostPath:
       path: /fs/ess
       type: Directory
+  nodeSelector:
+    cluster: "test"
 ---
 apiVersion: v1
 kind: Service

--- a/spec/job/adapters/kubernetes/batch_spec.rb
+++ b/spec/job/adapters/kubernetes/batch_spec.rb
@@ -306,7 +306,10 @@ describe OodCore::Job::Adapters::Kubernetes::Batch do
             host_type: 'Directory',
             destination_path: '/fs/ess',
             path: '/fs/ess'
-          ]
+          ],
+          node_selector: {
+            cluster: 'test',
+          }
         }
       )
 


### PR DESCRIPTION
Replaces #262, this can be used to select a node by the node's labels which could be used to choose a cluster or to choose a specific kind of GPU when requesting GPUs.