### PR TITLE
bump version and update changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+## [0.16.1] - 2021-04-23
+### Fixed
+- memorized some allow? variables to have better support around ACLS in
+  [267](https://github.com/OSC/ood_core/pull/267)
+
 ## [0.16.0] - 2021-04-20
 ### Fixed
 - tmux 2.7+ bug in the linux host adapter in [2.5.8](https://github.com/OSC/ood_core/pull/258)
@@ -300,8 +305,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Added
 - Initial release!
 
-[Unreleased]: https://github.com/OSC/ood_core/compare/v0.16.0...HEAD
-[0.15.2]: https://github.com/OSC/ood_core/compare/v0.15.1...v0.16.0
+[Unreleased]: https://github.com/OSC/ood_core/compare/v0.16.1...HEAD
+[0.16.1]: https://github.com/OSC/ood_core/compare/v0.16.0...v0.16.1
+[0.16.0]: https://github.com/OSC/ood_core/compare/v0.15.1...v0.16.0
 [0.15.1]: https://github.com/OSC/ood_core/compare/v0.15.0...v0.15.1
 [0.15.0]: https://github.com/OSC/ood_core/compare/v0.14.0...v0.15.0
 [0.14.0]: https://github.com/OSC/ood_core/compare/v0.13.0...v0.14.0

--- a/lib/ood_core/version.rb
+++ b/lib/ood_core/version.rb
@@ -1,4 +1,4 @@
 module OodCore
   # The current version of {OodCore}
-  VERSION = "0.16.0"
+  VERSION = "0.16.1"
 end


### PR DESCRIPTION
Simple changelog and version updates for the next release `v1.16.1`.