### PR TITLE
Allow changing K8 imagePullPolicy

### DIFF
--- a/lib/ood_core/job/adapters/kubernetes/helper.rb
+++ b/lib/ood_core/job/adapters/kubernetes/helper.rb
@@ -53,6 +53,7 @@ class OodCore::Job::Adapters::Kubernetes::Helper
       cpu: container[:cpu],
       working_dir: container[:working_dir],
       restart_policy: container[:restart_policy],
+      image_pull_policy: container[:image_pull_policy],
       image_pull_secret: container[:image_pull_secret]
     )
   end

--- a/lib/ood_core/job/adapters/kubernetes/resources.rb
+++ b/lib/ood_core/job/adapters/kubernetes/resources.rb
@@ -35,11 +35,11 @@ module OodCore::Job::Adapters::Kubernetes::Resources
 
   class Container
     attr_accessor :name, :image, :command, :port, :env, :memory, :cpu, :working_dir,
-                  :restart_policy, :image_pull_secret, :supplemental_groups
+                  :restart_policy, :image_pull_policy, :image_pull_secret, :supplemental_groups
 
     def initialize(
         name, image, command: [], port: nil, env: {}, memory: "4Gi", cpu: "1",
-        working_dir: "", restart_policy: "Never", image_pull_secret: nil, supplemental_groups: []
+        working_dir: "", restart_policy: "Never", image_pull_policy: nil, image_pull_secret: nil, supplemental_groups: []
       )
       raise ArgumentError, "containers need valid names and images" unless name && image
 
@@ -52,6 +52,7 @@ module OodCore::Job::Adapters::Kubernetes::Resources
       @cpu = cpu.nil? ? "1" : cpu
       @working_dir = working_dir.nil? ? "" : working_dir
       @restart_policy = restart_policy.nil? ? "Never" : restart_policy
+      @image_pull_policy = image_pull_policy.nil? ? "IfNotPresent" : image_pull_policy
       @image_pull_secret = image_pull_secret
       @supplemental_groups = supplemental_groups.nil? ? [] : supplemental_groups
     end
@@ -66,6 +67,7 @@ module OodCore::Job::Adapters::Kubernetes::Resources
         cpu == other.cpu &&
         working_dir == other.working_dir &&
         restart_policy == other.restart_policy &&
+        image_pull_policy == other.image_pull_policy &&
         image_pull_secret == other.image_pull_secret &&
         supplemental_groups == other.supplemental_groups
     end

--- a/lib/ood_core/job/adapters/kubernetes/templates/pod.yml.erb
+++ b/lib/ood_core/job/adapters/kubernetes/templates/pod.yml.erb
@@ -39,7 +39,7 @@ spec:
   containers:
   - name: "<%= spec.container.name %>"
     image: <%= spec.container.image %>
-    imagePullPolicy: IfNotPresent
+    imagePullPolicy: <%= spec.container.image_pull_policy %>
     <%- unless spec.container.working_dir.empty? -%>
     workingDir: "<%= spec.container.working_dir %>"
     <%- end -%>
@@ -95,6 +95,7 @@ spec:
   <%- spec.init_containers.each do |ctr| -%>
   - name: "<%= ctr.name %>"
     image: "<%= ctr.image %>"
+    imagePullPolicy: <%= ctr.image_pull_policy %>
     env:
     - name: POD_NAME
       valueFrom:

--- a/spec/fixtures/output/k8s/pod_yml_from_all_configs.yml
+++ b/spec/fixtures/output/k8s/pod_yml_from_all_configs.yml
@@ -25,7 +25,7 @@ spec:
   containers:
   - name: "rspec-test"
     image: ruby:2.5
-    imagePullPolicy: IfNotPresent
+    imagePullPolicy: Always
     workingDir: "/my/home"
     env:
     - name: POD_NAME
@@ -74,6 +74,7 @@ spec:
   initContainers:
   - name: "init-1"
     image: "busybox:latest"
+    imagePullPolicy: Always
     env:
     - name: POD_NAME
       valueFrom:

--- a/spec/fixtures/output/k8s/pod_yml_from_defaults.yml
+++ b/spec/fixtures/output/k8s/pod_yml_from_defaults.yml
@@ -68,6 +68,7 @@ spec:
   initContainers:
   - name: "init-1"
     image: "busybox:latest"
+    imagePullPolicy: IfNotPresent
     env:
     - name: POD_NAME
       valueFrom:

--- a/spec/fixtures/output/k8s/pod_yml_no_mounts.yml
+++ b/spec/fixtures/output/k8s/pod_yml_no_mounts.yml
@@ -66,6 +66,7 @@ spec:
   initContainers:
   - name: "init-1"
     image: "busybox:latest"
+    imagePullPolicy: IfNotPresent
     env:
     - name: POD_NAME
       valueFrom:

--- a/spec/fixtures/output/k8s/pod_yml_no_mounts_no_configmaps.yml
+++ b/spec/fixtures/output/k8s/pod_yml_no_mounts_no_configmaps.yml
@@ -63,6 +63,7 @@ spec:
   initContainers:
   - name: "init-1"
     image: "busybox:latest"
+    imagePullPolicy: IfNotPresent
     env:
     - name: POD_NAME
       valueFrom:

--- a/spec/fixtures/output/k8s/pod_yml_subpath_configmap.yml
+++ b/spec/fixtures/output/k8s/pod_yml_subpath_configmap.yml
@@ -72,6 +72,7 @@ spec:
   initContainers:
   - name: "init-1"
     image: "busybox:latest"
+    imagePullPolicy: IfNotPresent
     env:
     - name: POD_NAME
       valueFrom:

--- a/spec/job/adapters/kubernetes/batch_spec.rb
+++ b/spec/job/adapters/kubernetes/batch_spec.rb
@@ -277,6 +277,7 @@ describe OodCore::Job::Adapters::Kubernetes::Batch do
             name: 'rspec-test',
             image: 'ruby:2.5',
             image_pull_secret: 'docker-registry-secret',
+            image_pull_policy: 'Always',
             command: 'rake spec',
             port: 8080,
             env: {
@@ -291,6 +292,7 @@ describe OodCore::Job::Adapters::Kubernetes::Batch do
           init_containers: [
             name: 'init-1',
             image: 'busybox:latest',
+            image_pull_policy: 'Always',
             command: '/bin/ls -lrt .'
           ],
           configmap: {


### PR DESCRIPTION
Without this change, and doing app development, it becomes the case I have to create a unique tag for each test and that will pollute the K8 worker nodes with lots of images when easier to just use `latest` tag during testing and force images to always pull.  I could easily create a Kyverno mutation policy to force the pull policy but other sites might not want to deploy Kyverno or something like it.