### PR TITLE
Ensure all K8 resources have same labels

### DIFF
--- a/lib/ood_core/job/adapters/kubernetes/templates/pod.yml.erb
+++ b/lib/ood_core/job/adapters/kubernetes/templates/pod.yml.erb
@@ -176,6 +176,8 @@ metadata:
   namespace: <%= namespace %>
   labels:
     job: <%= id %>
+    app.kubernetes.io/name: <%= container.name %>
+    app.kubernetes.io/managed-by: open-ondemand
 spec:
   selector:
     job: <%= id %>
@@ -194,6 +196,8 @@ metadata:
   namespace: <%= namespace %>
   labels:
     job: <%= id %>
+    app.kubernetes.io/name: <%= container.name %>
+    app.kubernetes.io/managed-by: open-ondemand
 data:
 <%- configmap.files.each do |file| -%>
   <%- next if file.data.nil? || file.filename.nil? -%>

--- a/spec/fixtures/output/k8s/pod_yml_from_all_configs.yml
+++ b/spec/fixtures/output/k8s/pod_yml_from_all_configs.yml
@@ -145,6 +145,8 @@ metadata:
   namespace: user-testuser
   labels:
     job: rspec-test-123
+    app.kubernetes.io/name: rspec-test
+    app.kubernetes.io/managed-by: open-ondemand
 spec:
   selector:
     job: rspec-test-123
@@ -161,6 +163,8 @@ metadata:
   namespace: user-testuser
   labels:
     job: rspec-test-123
+    app.kubernetes.io/name: rspec-test
+    app.kubernetes.io/managed-by: open-ondemand
 data:
   config.file: |
     a = b

--- a/spec/fixtures/output/k8s/pod_yml_from_defaults.yml
+++ b/spec/fixtures/output/k8s/pod_yml_from_defaults.yml
@@ -123,6 +123,8 @@ metadata:
   namespace: testuser
   labels:
     job: rspec-test-123
+    app.kubernetes.io/name: rspec-test
+    app.kubernetes.io/managed-by: open-ondemand
 spec:
   selector:
     job: rspec-test-123
@@ -139,6 +141,8 @@ metadata:
   namespace: testuser
   labels:
     job: rspec-test-123
+    app.kubernetes.io/name: rspec-test
+    app.kubernetes.io/managed-by: open-ondemand
 data:
   config.file: |
     a = b

--- a/spec/fixtures/output/k8s/pod_yml_no_mounts.yml
+++ b/spec/fixtures/output/k8s/pod_yml_no_mounts.yml
@@ -114,6 +114,8 @@ metadata:
   namespace: testuser
   labels:
     job: rspec-test-123
+    app.kubernetes.io/name: rspec-test
+    app.kubernetes.io/managed-by: open-ondemand
 spec:
   selector:
     job: rspec-test-123
@@ -130,6 +132,8 @@ metadata:
   namespace: testuser
   labels:
     job: rspec-test-123
+    app.kubernetes.io/name: rspec-test
+    app.kubernetes.io/managed-by: open-ondemand
 data:
   config.file: |
     a = b

--- a/spec/fixtures/output/k8s/pod_yml_no_mounts_no_configmaps.yml
+++ b/spec/fixtures/output/k8s/pod_yml_no_mounts_no_configmaps.yml
@@ -111,6 +111,8 @@ metadata:
   namespace: testuser
   labels:
     job: rspec-test-123
+    app.kubernetes.io/name: rspec-test
+    app.kubernetes.io/managed-by: open-ondemand
 spec:
   selector:
     job: rspec-test-123
@@ -127,6 +129,8 @@ metadata:
   namespace: testuser
   labels:
     job: rspec-test-123
+    app.kubernetes.io/name: rspec-test
+    app.kubernetes.io/managed-by: open-ondemand
 data:
   config.file: |
     a = b

--- a/spec/fixtures/output/k8s/pod_yml_subpath_configmap.yml
+++ b/spec/fixtures/output/k8s/pod_yml_subpath_configmap.yml
@@ -125,6 +125,8 @@ metadata:
   namespace: testuser
   labels:
     job: rspec-test-123
+    app.kubernetes.io/name: rspec-test
+    app.kubernetes.io/managed-by: open-ondemand
 spec:
   selector:
     job: rspec-test-123
@@ -141,6 +143,8 @@ metadata:
   namespace: testuser
   labels:
     job: rspec-test-123
+    app.kubernetes.io/name: rspec-test
+    app.kubernetes.io/managed-by: open-ondemand
 data:
   config.file: |
     a = b


### PR DESCRIPTION
This ensure the logic job-pod-reaper can be the same for pods as well as other resources and makes finding orphaned resources easier. Already during testing I've found some stray services left behind so this ensures it's possible to reap orphaned objects.