### PR TITLE
Kubernetes - avoid empty initContainers definition

### DIFF
--- a/lib/ood_core/job/adapters/kubernetes/templates/pod.yml.erb
+++ b/lib/ood_core/job/adapters/kubernetes/templates/pod.yml.erb
@@ -94,7 +94,7 @@ spec:
         drop:
         - all
       privileged: false
-  <%- unless spec.init_containers.nil? -%>
+  <%- unless spec.init_containers.empty? -%>
   initContainers:
   <%- spec.init_containers.each do |ctr| -%>
   - name: "<%= ctr.name %>"

--- a/spec/fixtures/output/k8s/pod_yml_no_init_container.yml
+++ b/spec/fixtures/output/k8s/pod_yml_no_init_container.yml
@@ -1,0 +1,112 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  namespace: testuser
+  name: rspec-test-123
+  labels:
+    job: rspec-test-123
+    app.kubernetes.io/name: rspec-test
+    app.kubernetes.io/managed-by: open-ondemand
+    account: test
+  annotations:
+spec:
+  restartPolicy: Always
+  securityContext:
+    runAsUser: 1001
+    runAsGroup: 1002
+    runAsNonRoot: true
+    supplementalGroups: []
+    fsGroup: 1002
+  hostNetwork: false
+  hostIPC: false
+  hostPID: false
+  containers:
+  - name: "rspec-test"
+    image: ruby:2.5
+    imagePullPolicy: IfNotPresent
+    workingDir: "/my/home"
+    env:
+    - name: POD_NAME
+      valueFrom:
+        fieldRef:
+          fieldPath: metadata.name
+    - name: POD_NAMESPACE
+      valueFrom:
+        fieldRef:
+          fieldPath: metadata.namespace
+    - name: USER
+      value: "testuser"
+    - name: UID
+      value: "1001"
+    - name: HOME
+      value: "/my/home"
+    - name: GROUP
+      value: "testgroup"
+    - name: GID
+      value: "1002"
+    - name: PATH
+      value: "/usr/bin:/usr/local/bin"
+    command:
+    - "rake"
+    - "spec"
+    ports:
+    - containerPort: 8080
+    volumeMounts:
+    - name: configmap-volume
+      mountPath: /ood
+    - name: ess
+      mountPath: /fs/ess
+    resources:
+      limits:
+        memory: "6Gi"
+        cpu: "4"
+      requests:
+        memory: "6Gi"
+        cpu: "4"
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - all
+      privileged: false
+  volumes:
+  - name: configmap-volume
+    configMap:
+      name: rspec-test-123-configmap
+  - name: ess
+    hostPath:
+      path: /fs/ess
+      type: Directory
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: rspec-test-123-service
+  namespace: testuser
+  labels:
+    job: rspec-test-123
+    app.kubernetes.io/name: rspec-test
+    app.kubernetes.io/managed-by: open-ondemand
+spec:
+  selector:
+    job: rspec-test-123
+  ports:
+  - protocol: TCP
+    port: 80
+    targetPort: 8080
+  type: NodePort
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: rspec-test-123-configmap
+  namespace: testuser
+  labels:
+    job: rspec-test-123
+    app.kubernetes.io/name: rspec-test
+    app.kubernetes.io/managed-by: open-ondemand
+data:
+  config.file: |
+    a = b
+    c = d
+      indentation = keepthis

--- a/spec/job/adapters/kubernetes/batch_spec.rb
+++ b/spec/job/adapters/kubernetes/batch_spec.rb
@@ -19,6 +19,7 @@ describe OodCore::Job::Adapters::Kubernetes::Batch do
 
   let(:pod_yml_from_all_configs) { File.read('spec/fixtures/output/k8s/pod_yml_from_all_configs.yml') }
   let(:pod_yml_from_defaults) { File.read('spec/fixtures/output/k8s/pod_yml_from_defaults.yml') }
+  let(:pod_yml_no_init_container) { File.read('spec/fixtures/output/k8s/pod_yml_no_init_container.yml') }
   let(:pod_yml_no_mounts) { File.read('spec/fixtures/output/k8s/pod_yml_no_mounts.yml') }
   let(:pod_yml_subpath_configmap) { File.read('spec/fixtures/output/k8s/pod_yml_subpath_configmap.yml') }
   let(:pod_yml_no_mounts_no_configmaps) { File.read('spec/fixtures/output/k8s/pod_yml_no_mounts_no_configmaps.yml') }
@@ -449,6 +450,62 @@ describe OodCore::Job::Adapters::Kubernetes::Batch do
         "--namespace=testuser -o json create -f -",
         stdin_data: pod_yml_no_mounts.to_s
       ).and_return(['', '', $?])
+
+      @basic_batch.submit(script)
+    end
+
+    it "submits with correct yml file given no init containers" do
+      script = build_script(
+        accounting_id: 'test',
+        native: {
+          container: {
+            name: 'rspec-test',
+            image: 'ruby:2.5',
+            command: 'rake spec',
+            port: 8080,
+            env: {
+              'HOME' => '/my/home',
+              'PATH' => '/usr/bin:/usr/local/bin'
+            },
+            memory: '6Gi',
+            cpu: '4',
+            working_dir: '/my/home',
+            restart_policy: 'Always'
+          },
+          configmap: {
+            files: [{
+              filename: 'config.file',
+              data: "a = b\nc = d\n  indentation = keepthis",
+              mount_path: '/ood'
+            }],
+          },
+          mounts: [
+            type: 'host',
+            name: 'ess',
+            host_type: 'Directory',
+            destination_path: '/fs/ess',
+            path: '/fs/ess'
+          ]
+        }
+      )
+
+      allow(@basic_batch).to receive(:generate_id).with('rspec-test').and_return('rspec-test-123')
+      allow(@basic_batch).to receive(:username).and_return('testuser')
+      allow(@basic_batch).to receive(:user).and_return(User.new(dir: '/home/testuser', uid: 1001, gid: 1002))
+      allow(@basic_batch).to receive(:group).and_return('testgroup')
+
+      # make sure it get's templated right, also helpful in debugging bc
+      # it'll show a better diff than the test below.
+      template, = @basic_batch.send(:generate_id_yml, script)
+      expect(template.to_s).to eql(pod_yml_no_init_container.to_s)
+
+      # make sure template get's passed into command correctly
+      allow(Open3).to receive(:capture3).with(
+        {},
+        "/usr/bin/kubectl --kubeconfig=#{ENV['HOME']}/.kube/config " \
+        "--namespace=testuser -o json create -f -",
+        stdin_data: pod_yml_no_init_container.to_s
+      ).and_return(['', '', success])
 
       @basic_batch.submit(script)
     end


### PR DESCRIPTION
Noticed that a definition with no init containers defined still had `initContainers` in YAML:

```
    securityContext:
      allowPrivilegeEscalation: false
      capabilities:
        drop:
        - all
      privileged: false
  initContainers:
  volumes:
```

This didn't seem to break anything, just a bit of clean up.