### PR TITLE
Add cluster batch_connect_ssh_allow? function to allow easier access to a new setting

### DIFF
--- a/lib/ood_core/cluster.rb
+++ b/lib/ood_core/cluster.rb
@@ -147,6 +147,15 @@ module OodCore
       @allow = acls.all?(&:allow?)
     end
 
+    # Whether this cluster supports SSH to batch connect nodes
+    # @return [Boolean] whether cluster supports SSH to batch connect node
+    def batch_connect_ssh_allow?(default = true)
+      return @batch_connect_ssh_allow if defined?(@batch_connect_ssh_allow)
+      return @batch_connect_ssh_allow = default if batch_connect_config.nil?
+
+      @batch_connect_ssh_allow = batch_connect_config.fetch(:ssh_allow, default)
+    end
+
     # The comparison operator
     # @param other [#to_sym] object to compare against
     # @return [Boolean] whether objects are equivalent

--- a/lib/ood_core/cluster.rb
+++ b/lib/ood_core/cluster.rb
@@ -149,11 +149,11 @@ module OodCore
 
     # Whether this cluster supports SSH to batch connect nodes
     # @return [Boolean] whether cluster supports SSH to batch connect node
-    def batch_connect_ssh_allow?(default = true)
+    def batch_connect_ssh_allow?
       return @batch_connect_ssh_allow if defined?(@batch_connect_ssh_allow)
-      return @batch_connect_ssh_allow = default if batch_connect_config.nil?
+      return @batch_connect_ssh_allow = true if batch_connect_config.nil?
 
-      @batch_connect_ssh_allow = batch_connect_config.fetch(:ssh_allow, default)
+      @batch_connect_ssh_allow = batch_connect_config.fetch(:ssh_allow, true)
     end
 
     # The comparison operator

--- a/spec/cluster_spec.rb
+++ b/spec/cluster_spec.rb
@@ -51,6 +51,20 @@ describe OodCore::Cluster do
         expect(owens).to receive(:allow?).once
         2.times { owens.login_allow? }
       end
+
+      it 'has default for batch_connect_ssh_allow?' do
+        expect(owens.batch_connect_ssh_allow?).to be true
+      end
+
+      it 'can disable batch_connect_ssh_allow?' do
+        owens = OodCore::Cluster.new({id: "owens", batch_connect: { ssh_allow: false } })
+        expect(owens.batch_connect_ssh_allow?).to be false
+      end
+
+      it "caches batch_connect_ssh_allow?" do
+        expect(owens).to receive(:batch_connect_config).once
+        2.times { owens.batch_connect_ssh_allow? }
+      end
     end
   end
 


### PR DESCRIPTION
Add cluster batch_connect_ssh_allow? function to allow easier access to a new setting:

```
batch_connect:
  ssh_allow: <boolean>
```
Needed for https://github.com/OSC/ondemand/issues/1157

Not sure if this is best approach or if better to just add all the logic to OnDemand dashboard app to look for a certain config inside the cluster `batch_connect` settings.