### PR TITLE
Allow cluster batch_connect_ssh_allow? to return nil if not defined

### DIFF
--- a/lib/ood_core/cluster.rb
+++ b/lib/ood_core/cluster.rb
@@ -148,12 +148,12 @@ module OodCore
     end
 
     # Whether this cluster supports SSH to batch connect nodes
-    # @return [Boolean] whether cluster supports SSH to batch connect node
+    # @return [Boolean, nil] whether cluster supports SSH to batch connect node
     def batch_connect_ssh_allow?
       return @batch_connect_ssh_allow if defined?(@batch_connect_ssh_allow)
-      return @batch_connect_ssh_allow = true if batch_connect_config.nil?
+      return @batch_connect_ssh_allow = nil if batch_connect_config.nil?
 
-      @batch_connect_ssh_allow = batch_connect_config.fetch(:ssh_allow, true)
+      @batch_connect_ssh_allow = batch_connect_config.fetch(:ssh_allow, nil)
     end
 
     # The comparison operator

--- a/spec/cluster_spec.rb
+++ b/spec/cluster_spec.rb
@@ -53,6 +53,11 @@ describe OodCore::Cluster do
       end
 
       it 'has default for batch_connect_ssh_allow?' do
+        expect(owens.batch_connect_ssh_allow?).to be_nil
+      end
+
+      it 'can enable batch_connect_ssh_allow?' do
+        owens = OodCore::Cluster.new({id: "owens", batch_connect: { ssh_allow: true } })
         expect(owens.batch_connect_ssh_allow?).to be true
       end
 


### PR DESCRIPTION
Based on conversation from https://github.com/OSC/ondemand/pull/1173