### PR TITLE
Expose pod port as environment variable

### DIFF
--- a/lib/ood_core/job/adapters/kubernetes/templates/pod.yml.erb
+++ b/lib/ood_core/job/adapters/kubernetes/templates/pod.yml.erb
@@ -52,6 +52,10 @@ spec:
       valueFrom:
         fieldRef:
           fieldPath: metadata.namespace
+    <%- unless spec.container.port.nil? -%>
+    - name: POD_PORT
+      value: "<%= spec.container.port %>"
+    <%- end -%>
     <%- spec.container.env.each_pair do |name, value| -%>
     - name: <%= name %>
       value: "<%= value %>"

--- a/spec/fixtures/output/k8s/pod_yml_from_all_configs.yml
+++ b/spec/fixtures/output/k8s/pod_yml_from_all_configs.yml
@@ -36,6 +36,8 @@ spec:
       valueFrom:
         fieldRef:
           fieldPath: metadata.namespace
+    - name: POD_PORT
+      value: "8080"
     - name: USER
       value: "testuser"
     - name: UID

--- a/spec/fixtures/output/k8s/pod_yml_from_defaults.yml
+++ b/spec/fixtures/output/k8s/pod_yml_from_defaults.yml
@@ -34,6 +34,8 @@ spec:
       valueFrom:
         fieldRef:
           fieldPath: metadata.namespace
+    - name: POD_PORT
+      value: "8080"
     - name: USER
       value: "testuser"
     - name: UID

--- a/spec/fixtures/output/k8s/pod_yml_no_configmaps.yml
+++ b/spec/fixtures/output/k8s/pod_yml_no_configmaps.yml
@@ -34,6 +34,8 @@ spec:
       valueFrom:
         fieldRef:
           fieldPath: metadata.namespace
+    - name: POD_PORT
+      value: "8080"
     - name: USER
       value: "testuser"
     - name: UID

--- a/spec/fixtures/output/k8s/pod_yml_no_init_container.yml
+++ b/spec/fixtures/output/k8s/pod_yml_no_init_container.yml
@@ -34,6 +34,8 @@ spec:
       valueFrom:
         fieldRef:
           fieldPath: metadata.namespace
+    - name: POD_PORT
+      value: "8080"
     - name: USER
       value: "testuser"
     - name: UID

--- a/spec/fixtures/output/k8s/pod_yml_no_mounts.yml
+++ b/spec/fixtures/output/k8s/pod_yml_no_mounts.yml
@@ -34,6 +34,8 @@ spec:
       valueFrom:
         fieldRef:
           fieldPath: metadata.namespace
+    - name: POD_PORT
+      value: "8080"
     - name: USER
       value: "testuser"
     - name: UID

--- a/spec/fixtures/output/k8s/pod_yml_no_mounts_no_configmaps.yml
+++ b/spec/fixtures/output/k8s/pod_yml_no_mounts_no_configmaps.yml
@@ -34,6 +34,8 @@ spec:
       valueFrom:
         fieldRef:
           fieldPath: metadata.namespace
+    - name: POD_PORT
+      value: "8080"
     - name: USER
       value: "testuser"
     - name: UID

--- a/spec/fixtures/output/k8s/pod_yml_subpath_configmap.yml
+++ b/spec/fixtures/output/k8s/pod_yml_subpath_configmap.yml
@@ -34,6 +34,8 @@ spec:
       valueFrom:
         fieldRef:
           fieldPath: metadata.namespace
+    - name: POD_PORT
+      value: "8080"
     - name: USER
       value: "testuser"
     - name: UID


### PR DESCRIPTION
This is useful to avoid hardcoding port numbers into batch connect job templates and can also be used to pass the port number to commands launching a container.