### PR TITLE
Support Kubernetes startupProbe

### DIFF
--- a/lib/ood_core/job/adapters/kubernetes/helper.rb
+++ b/lib/ood_core/job/adapters/kubernetes/helper.rb
@@ -54,7 +54,8 @@ class OodCore::Job::Adapters::Kubernetes::Helper
       working_dir: container[:working_dir],
       restart_policy: container[:restart_policy],
       image_pull_policy: container[:image_pull_policy],
-      image_pull_secret: container[:image_pull_secret]
+      image_pull_secret: container[:image_pull_secret],
+      startup_probe: container[:startup_probe],
     )
   end
 

--- a/lib/ood_core/job/adapters/kubernetes/resources.rb
+++ b/lib/ood_core/job/adapters/kubernetes/resources.rb
@@ -33,11 +33,12 @@ module OodCore::Job::Adapters::Kubernetes::Resources
     end
   end
 
-  class Probe
-    attr_accessor :initial_delay_seconds, :failure_threshold, :period_seconds
+  class TCPProbe
+    attr_accessor :port, :initial_delay_seconds, :failure_threshold, :period_seconds
 
-    def initialize(data)
+    def initialize(port, data)
       data ||= {}
+      @port = port
       @initial_delay_seconds = data[:initial_delay_seconds] || 2
       @failure_threshold = data[:failure_threshold] || 5
       @period_seconds = data[:period_seconds] || 5
@@ -45,23 +46,11 @@ module OodCore::Job::Adapters::Kubernetes::Resources
 
     def to_h
       {
+        port: port,
         initial_delay_seconds: initial_delay_seconds,
         failure_threshold: failure_threshold,
         period_seconds: period_seconds,
       }
-    end
-  end
-
-  class TCPProbe < Probe
-    attr_accessor :port
-
-    def initialize(port, data)
-      super(data)
-      @port = port
-    end
-
-    def to_h
-      super.merge({port: port})
     end
   end
 

--- a/lib/ood_core/job/adapters/kubernetes/templates/pod.yml.erb
+++ b/lib/ood_core/job/adapters/kubernetes/templates/pod.yml.erb
@@ -65,6 +65,12 @@ spec:
     <%- unless spec.container.port.nil? -%>
     ports:
     - containerPort: <%= spec.container.port %>
+    startupProbe:
+      tcpSocket:
+        port: <%= spec.container.startup_probe.port %>
+      initialDelaySeconds: <%= spec.container.startup_probe.initial_delay_seconds %>
+      failureThreshold: <%= spec.container.startup_probe.failure_threshold %>
+      periodSeconds: <%= spec.container.startup_probe.period_seconds %>
     <%- end -%>
     <%- if !all_mounts.empty? || (!configmap.nil? && configmap.mounts?) -%>
     volumeMounts:

--- a/spec/fixtures/output/k8s/pod_yml_from_all_configs.yml
+++ b/spec/fixtures/output/k8s/pod_yml_from_all_configs.yml
@@ -53,6 +53,12 @@ spec:
     - "spec"
     ports:
     - containerPort: 8080
+    startupProbe:
+      tcpSocket:
+        port: 8080
+      initialDelaySeconds: 2
+      failureThreshold: 10
+      periodSeconds: 5
     volumeMounts:
     - name: configmap-volume
       mountPath: /ood

--- a/spec/fixtures/output/k8s/pod_yml_from_defaults.yml
+++ b/spec/fixtures/output/k8s/pod_yml_from_defaults.yml
@@ -51,6 +51,12 @@ spec:
     - "spec"
     ports:
     - containerPort: 8080
+    startupProbe:
+      tcpSocket:
+        port: 8080
+      initialDelaySeconds: 2
+      failureThreshold: 5
+      periodSeconds: 5
     volumeMounts:
     - name: configmap-volume
       mountPath: /ood

--- a/spec/fixtures/output/k8s/pod_yml_no_configmaps.yml
+++ b/spec/fixtures/output/k8s/pod_yml_no_configmaps.yml
@@ -51,6 +51,12 @@ spec:
     - "spec"
     ports:
     - containerPort: 8080
+    startupProbe:
+      tcpSocket:
+        port: 8080
+      initialDelaySeconds: 2
+      failureThreshold: 5
+      periodSeconds: 5
     volumeMounts:
     - name: configmap-volume
       mountPath: /ood/script.sh

--- a/spec/fixtures/output/k8s/pod_yml_no_init_container.yml
+++ b/spec/fixtures/output/k8s/pod_yml_no_init_container.yml
@@ -51,6 +51,12 @@ spec:
     - "spec"
     ports:
     - containerPort: 8080
+    startupProbe:
+      tcpSocket:
+        port: 8080
+      initialDelaySeconds: 2
+      failureThreshold: 5
+      periodSeconds: 5
     volumeMounts:
     - name: configmap-volume
       mountPath: /ood

--- a/spec/fixtures/output/k8s/pod_yml_no_mounts.yml
+++ b/spec/fixtures/output/k8s/pod_yml_no_mounts.yml
@@ -51,6 +51,12 @@ spec:
     - "spec"
     ports:
     - containerPort: 8080
+    startupProbe:
+      tcpSocket:
+        port: 8080
+      initialDelaySeconds: 2
+      failureThreshold: 5
+      periodSeconds: 5
     volumeMounts:
     - name: configmap-volume
       mountPath: /ood

--- a/spec/fixtures/output/k8s/pod_yml_no_mounts_no_configmaps.yml
+++ b/spec/fixtures/output/k8s/pod_yml_no_mounts_no_configmaps.yml
@@ -51,6 +51,12 @@ spec:
     - "spec"
     ports:
     - containerPort: 8080
+    startupProbe:
+      tcpSocket:
+        port: 8080
+      initialDelaySeconds: 2
+      failureThreshold: 5
+      periodSeconds: 5
     volumeMounts:
     - name: configmap-volume
       mountPath: /ood/script.sh

--- a/spec/fixtures/output/k8s/pod_yml_subpath_configmap.yml
+++ b/spec/fixtures/output/k8s/pod_yml_subpath_configmap.yml
@@ -51,6 +51,12 @@ spec:
     - "spec"
     ports:
     - containerPort: 8080
+    startupProbe:
+      tcpSocket:
+        port: 8080
+      initialDelaySeconds: 2
+      failureThreshold: 5
+      periodSeconds: 5
     volumeMounts:
     - name: configmap-volume
       mountPath: /ood

--- a/spec/job/adapters/kubernetes/batch_spec.rb
+++ b/spec/job/adapters/kubernetes/batch_spec.rb
@@ -293,6 +293,7 @@ EOS
             image_pull_policy: 'Always',
             command: 'rake spec',
             port: 8080,
+            startup_probe: { failure_threshold: 10 },
             env: {
               HOME: '/my/home',
               PATH: '/usr/bin:/usr/local/bin'


### PR DESCRIPTION
This will have same idea as the `after.sh.erb` used by HPC batch connect apps, the pod won't report as `Running` until the TCP port defined for the pod is actually up.  I tried to make the class structure such that we could switch to a HTTP probe instead of TCP just by adding a new class in the future.  I opted for TCP probe over HTTP probe because didn't want to have to worry about which path for HTTP probe would respond with 200 status code which could vary greatly between batch connect apps.  Using a TCP probe seemed more universal.