### PR TITLE
dont save gh action files

### DIFF
--- a/ood_core.gemspec
+++ b/ood_core.gemspec
@@ -15,7 +15,7 @@ Gem::Specification.new do |spec|
   spec.license       = "MIT"
 
   spec.files         = `git ls-files -z`.split("\x0").reject do |f|
-    f.match(%r{^(test|spec|features)/})
+    f.match(%r{^(test|spec|features|.github)/})
   end
   spec.bindir        = "exe"
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }


### PR DESCRIPTION
dont save gh action files. There's no security risk or anything, they just don't need to be distributed.