### PR TITLE
Lha ssh output crash

### DIFF
--- a/lib/ood_core/job/adapters/linux_host/launcher.rb
+++ b/lib/ood_core/job/adapters/linux_host/launcher.rb
@@ -61,8 +61,6 @@ class OodCore::Job::Adapters::LinuxHost::Launcher
 
     session_name = unique_session_name
     output = call(*cmd, stdin: wrapped_script(script, session_name))
-    # add helper function to make sure this isn't just stripping the string of \n
-    # and actually processing the string to hand us what we expect for the job id.
     hostname = parse_hostname(output)
 
     "#{session_name}@#{hostname}"

--- a/lib/ood_core/job/adapters/linux_host/launcher.rb
+++ b/lib/ood_core/job/adapters/linux_host/launcher.rb
@@ -242,22 +242,22 @@ class OodCore::Job::Adapters::LinuxHost::Launcher
   def list_remote_tmux_session(destination_host)
     # Note that the tmux variable substitution looks like Ruby string sub,
     # these must either be single quoted strings or Ruby-string escaped as well
-    format_str = Shellwords.escape(
-      ['#{session_name}', '#{session_created}', '#{pane_pid}'].join(UNIT_SEPARATOR)
-    )
+    format_str = Shellwords.escape(['#{session_name}', '#{session_created}', '#{pane_pid}'].join(UNIT_SEPARATOR))
     keys = [:session_name, :session_created, :session_pid]
     cmd = ssh_cmd(destination_host, ['tmux', 'list-panes', '-aF', format_str])
-
-    call(*cmd).split(
-      "\n"
-    ).map do |line|
+    
+    call(*cmd).split("\n").map do |line|
       Hash[keys.zip(line.split(UNIT_SEPARATOR))].tap do |session_hash|
         session_hash[:destination_host] = destination_host
         session_hash[:id] = "#{session_hash[:session_name]}@#{destination_host}"
       end
-    end.select{
-      |session_hash| session_hash[:session_name].start_with?(session_name_label)
-    }
+    end.select do |session_hash| 
+      # delme
+      # prevent calling start_with? on nil.
+      if !session_hash[:session_name].nil?
+        session_hash[:session_name].start_with?(session_name_label)
+      end
+    end
   rescue Error => e
     interpret_and_raise(e)
     []

--- a/lib/ood_core/job/adapters/linux_host/launcher.rb
+++ b/lib/ood_core/job/adapters/linux_host/launcher.rb
@@ -289,9 +289,8 @@ class OodCore::Job::Adapters::LinuxHost::Launcher
   end
 
   def parse_hostname(output)
-    output_new_line_stripped = output.strip
-    #parsed_hostname = output_new_line_stripped.match(/\w+-\w+\.\w+\.\w+\.\w+/)
-    # ensure echo newline too
-    parsed_hostname = output_new_line_stripped.match(/^(([a-zA-Z]|[a-zA-Z0-9][a-zA-Z0-9\-]*[a-zA-Z0-9])\.)+([A-Za-z0-9]|[A-Za-z0-9][A-Za-z0-9\-]*[A-Za-z0-9])*$/)
+    output.split($/).map do |line|
+      line.match(/^(([\w+]|[a-zA-Z0-9][\w*-]*\.))*$/)
+    end.compact.last.to_s
   end
 end

--- a/lib/ood_core/job/adapters/linux_host/templates/script_wrapper.erb.sh
+++ b/lib/ood_core/job/adapters/linux_host/templates/script_wrapper.erb.sh
@@ -13,8 +13,8 @@ if [ -z "$hostname" ]; then
     exit 1
 fi
 
-echo $hostname
 echo ""
+echo $hostname
 
 # Put the script into a temp file on localhost
 singularity_tmp_file=$(mktemp -p "<%= workdir %>" --suffix '_sing')

--- a/lib/ood_core/job/adapters/linux_host/templates/script_wrapper.erb.sh
+++ b/lib/ood_core/job/adapters/linux_host/templates/script_wrapper.erb.sh
@@ -14,6 +14,7 @@ if [ -z "$hostname" ]; then
 fi
 
 echo $hostname
+echo ""
 
 # Put the script into a temp file on localhost
 singularity_tmp_file=$(mktemp -p "<%= workdir %>" --suffix '_sing')

--- a/lib/ood_core/version.rb
+++ b/lib/ood_core/version.rb
@@ -1,4 +1,4 @@
 module OodCore
   # The current version of {OodCore}
-  VERSION = "0.17.6"
+  VERSION = "0.17.1"
 end

--- a/lib/ood_core/version.rb
+++ b/lib/ood_core/version.rb
@@ -1,5 +1,4 @@
 module OodCore
   # The current version of {OodCore}
-  # delme iterate this to rebuild for dashboard
   VERSION = "0.17.6"
 end

--- a/lib/ood_core/version.rb
+++ b/lib/ood_core/version.rb
@@ -1,4 +1,5 @@
 module OodCore
   # The current version of {OodCore}
-  VERSION = "0.17.1"
+  # delme iterate this to rebuild for dashboard
+  VERSION = "0.17.7"
 end

--- a/lib/ood_core/version.rb
+++ b/lib/ood_core/version.rb
@@ -1,5 +1,5 @@
 module OodCore
   # The current version of {OodCore}
   # delme iterate this to rebuild for dashboard
-  VERSION = "0.17.7"
+  VERSION = "0.17.6"
 end

--- a/spec/job/adapters/linux_host/launcher_spec.rb
+++ b/spec/job/adapters/linux_host/launcher_spec.rb
@@ -107,19 +107,6 @@ describe OodCore::Job::Adapters::LinuxHost::Launcher do
         end
 
         context "When tmux returns extra data along with the hostname it" do
-            # let(:broken_data) { 
-            #     <<~HEREDOC
-            #     Code Server (launched-by-ondemand-74542f25-fa6e-4e33-8e47-
-            #     feb166af57a9@---------------- ----------------------------
-            #     -------- Usage Statistics for project PZS0714 Time 2021-09-16 to
-            #      2021-09-17 PI alanc@osc.edu Remaining Budget -0.25 
-            #      ---------------- ------------------------------------ 
-            #      User Jobs Dollars Status ------------- ------ --------- -------- 
-            #      alanc 0 0.0 ACTIVE johrstrom 15 0.0 ACTIVE johrstromtest 0 0.0 ACTIVE 
-            #      travert 9 0.0 ACTIVE -- -- -- TOTAL 24 0.0 
-            #      owens-login01.hpc.osc.edu )
-            #  HEREDOC
-            # }
             let(:broken_data) {
                 <<~HEREDOC
                 text and more text 
@@ -211,10 +198,10 @@ describe OodCore::Job::Adapters::LinuxHost::Launcher do
             travert        0       0.0        ACTIVE
             --             --      --
             TOTAL          0       0.0
-            launched-by-ondemand-a8e85cd4-791d-49fa-8be1-5bd5c1009d70,1569609529,175138
-            launched-by-ondemand-a8e85cd4-791d-49fa-8be1-5bd5c1009d70,1569609529
+            launched-by-ondemand-a8e85cd4-791d-49fa-8be1-5bd5c1009d70#{sep}1569609529#{sep}175138
+            launched-by-ondemand-a8e85cd4-791d-49fa-8be1-5bd5c1009d70#{sep}1569609529
             launched-by-ondemand-a8e85cd4-791d-49fa-8be1-5bd5c1009d70
-            a8e85cd4-791d-49fa-8be1-5bd5c1009d70,1569609529,175138
+            a8e85cd4-791d-49fa-8be1-5bd5c1009d70#{sep}1569609529#{sep}175138
          HEREDOC
         }
 

--- a/spec/job/adapters/linux_host/launcher_spec.rb
+++ b/spec/job/adapters/linux_host/launcher_spec.rb
@@ -107,24 +107,35 @@ describe OodCore::Job::Adapters::LinuxHost::Launcher do
         end
 
         context "When tmux returns extra data along with the hostname it" do
-            let(:broken_data) { 
+            # let(:broken_data) { 
+            #     <<~HEREDOC
+            #     Code Server (launched-by-ondemand-74542f25-fa6e-4e33-8e47-
+            #     feb166af57a9@---------------- ----------------------------
+            #     -------- Usage Statistics for project PZS0714 Time 2021-09-16 to
+            #      2021-09-17 PI alanc@osc.edu Remaining Budget -0.25 
+            #      ---------------- ------------------------------------ 
+            #      User Jobs Dollars Status ------------- ------ --------- -------- 
+            #      alanc 0 0.0 ACTIVE johrstrom 15 0.0 ACTIVE johrstromtest 0 0.0 ACTIVE 
+            #      travert 9 0.0 ACTIVE -- -- -- TOTAL 24 0.0 
+            #      owens-login01.hpc.osc.edu )
+            #  HEREDOC
+            # }
+            let(:broken_data) {
                 <<~HEREDOC
-                Code Server (launched-by-ondemand-74542f25-fa6e-4e33-8e47-
-                feb166af57a9@---------------- ----------------------------
-                -------- Usage Statistics for project PZS0714 Time 2021-09-16 to
-                 2021-09-17 PI alanc@osc.edu Remaining Budget -0.25 
-                 ---------------- ------------------------------------ 
-                 User Jobs Dollars Status ------------- ------ --------- -------- 
-                 alanc 0 0.0 ACTIVE johrstrom 15 0.0 ACTIVE johrstromtest 0 0.0 ACTIVE 
-                 travert 9 0.0 ACTIVE -- -- -- TOTAL 24 0.0 owens-login01.hpc.osc.edu)
-             HEREDOC
+                text and more text 
+                for filler
+                launched-by-ondemand-74542f25-fa6e-4e33-8e47-feb166af57a9@
+                some.bad.stuff@hpc
+                some.dot.stuff
+                owens-login01.hpc.osc.edu
+                more strings.
+            HEREDOC
             }
             it "parses remote host correctly" do
                 allow(Open3).to receive(:capture3).and_return([broken_data, '', exit_success])
 
-                expect{
-                    subject.start_remote_session(build_script).to match(/owens-login01\.hpc\.osc\.edu/)
-                }
+                session = subject.start_remote_session(build_script)
+                expect(session).to match(/^launched-by-ondemand.+@owens-login01\.hpc\.osc\.edu$/)
             end
         end
     end

--- a/spec/job/adapters/linux_host/launcher_spec.rb
+++ b/spec/job/adapters/linux_host/launcher_spec.rb
@@ -159,6 +159,22 @@ describe OodCore::Job::Adapters::LinuxHost::Launcher do
                 :session_pid=>"175138"
             }
         ] }
+        let(:tmux_broken_output) { "----------------  ------------------------------------
+            Usage Statistics for project PZS0714
+Time              2021-09-12 to 2021-09-13
+PI                alanc@osc.edu
+Remaining Budget  -0.25
+----------------  ------------------------------------
+
+User           Jobs    Dollars    Status
+-------------  ------  ---------  --------
+alanc          0       0.0        ACTIVE
+johrstrom      0       0.0        ACTIVE
+johrstromtest  0       0.0        ACTIVE
+travert        0       0.0        ACTIVE
+--             --      --
+TOTAL          0       0.0
+launched-by-ondemand-a8e85cd4-791d-49fa-8be1-5bd5c1009d70,1569609529,175138" }
 
         context "when host is set" do
             it "only connects to the one host and parses correctly" do
@@ -197,6 +213,17 @@ describe OodCore::Job::Adapters::LinuxHost::Launcher do
                 expect{
                     subject.list_remote_sessions
                 }.to raise_error(OodCore::Job::Adapters::LinuxHost::Launcher::Error)
+            end
+        end
+
+        context "When SSH output breaks OOD parsing for card" do
+            let(:owens_remote_host) { opts[:ssh_hosts].first }
+            it "still connects successfully" do
+                allow(Open3).to receive(:capture3).and_return([tmux_broken_output, '', exit_success])
+
+                expect(
+                    subject.list_remote_sessions(host: owens_remote_host)
+                ).to eq([parsed_tmux_output_x3.first])
             end
         end
     end

--- a/spec/job/adapters/linux_host/launcher_spec.rb
+++ b/spec/job/adapters/linux_host/launcher_spec.rb
@@ -105,6 +105,28 @@ describe OodCore::Job::Adapters::LinuxHost::Launcher do
                 subject.start_remote_session(build_script(native: {'submit_host_override' => alt_submit_host}))
             end
         end
+
+        context "When tmux returns extra data along with the hostname it" do
+            let(:broken_data) { 
+                <<~HEREDOC
+                Code Server (launched-by-ondemand-74542f25-fa6e-4e33-8e47-
+                feb166af57a9@---------------- ----------------------------
+                -------- Usage Statistics for project PZS0714 Time 2021-09-16 to
+                 2021-09-17 PI alanc@osc.edu Remaining Budget -0.25 
+                 ---------------- ------------------------------------ 
+                 User Jobs Dollars Status ------------- ------ --------- -------- 
+                 alanc 0 0.0 ACTIVE johrstrom 15 0.0 ACTIVE johrstromtest 0 0.0 ACTIVE 
+                 travert 9 0.0 ACTIVE -- -- -- TOTAL 24 0.0 owens-login01.hpc.osc.edu)
+             HEREDOC
+            }
+            it "parses remote host correctly" do
+                allow(Open3).to receive(:capture3).and_return([broken_data, '', exit_success])
+
+                expect{
+                    subject.start_remote_session(build_script).to match(/owens-login01\.hpc\.osc\.edu/)
+                }
+            end
+        end
     end
 
     describe "#stop_remote_session" do
@@ -135,6 +157,7 @@ describe OodCore::Job::Adapters::LinuxHost::Launcher do
 
     describe "#list_remote_sessions" do
         sep = OodCore::Job::Adapters::LinuxHost::Launcher::UNIT_SEPARATOR
+        let(:owens_remote_host) { opts[:ssh_hosts].first }
         let(:tmux_output_a) { "launched-by-ondemand-a8e85cd4-791d-49fa-8be1-5bd5c1009d70#{sep}1569609529#{sep}175138\n" }
         let(:tmux_output_b) { "launched-by-ondemand-b8e85cd4-791d-49fa-8be1-5bd5c1009d70#{sep}1569609529#{sep}175138\n" }
         let(:tmux_output_c) { "launched-by-ondemand-c8e85cd4-791d-49fa-8be1-5bd5c1009d70#{sep}1569609529#{sep}175138\n" }
@@ -159,22 +182,30 @@ describe OodCore::Job::Adapters::LinuxHost::Launcher do
                 :session_pid=>"175138"
             }
         ] }
-        let(:tmux_broken_output) { "----------------  ------------------------------------
-            Usage Statistics for project PZS0714
-Time              2021-09-12 to 2021-09-13
-PI                alanc@osc.edu
-Remaining Budget  -0.25
-----------------  ------------------------------------
 
-User           Jobs    Dollars    Status
--------------  ------  ---------  --------
-alanc          0       0.0        ACTIVE
-johrstrom      0       0.0        ACTIVE
-johrstromtest  0       0.0        ACTIVE
-travert        0       0.0        ACTIVE
---             --      --
-TOTAL          0       0.0
-launched-by-ondemand-a8e85cd4-791d-49fa-8be1-5bd5c1009d70,1569609529,175138" }
+        let(:tmux_broken_output_with_many_returned_fields) {
+            <<~HEREDOC
+            ----------------  ------------------------------------
+            Usage Statistics for project PZS0714
+            Time              2021-09-12 to 2021-09-13
+            PI                alanc@osc.edu
+            Remaining Budget  -0.25
+            ----------------  ------------------------------------
+
+            User           Jobs    Dollars    Status
+            -------------  ------  ---------  --------
+            alanc          0       0.0        ACTIVE
+            johrstrom      0       0.0        ACTIVE
+            johrstromtest  0       0.0        ACTIVE
+            travert        0       0.0        ACTIVE
+            --             --      --
+            TOTAL          0       0.0
+            launched-by-ondemand-a8e85cd4-791d-49fa-8be1-5bd5c1009d70,1569609529,175138
+            launched-by-ondemand-a8e85cd4-791d-49fa-8be1-5bd5c1009d70,1569609529
+            launched-by-ondemand-a8e85cd4-791d-49fa-8be1-5bd5c1009d70
+            a8e85cd4-791d-49fa-8be1-5bd5c1009d70,1569609529,175138
+         HEREDOC
+        }
 
         context "when host is set" do
             it "only connects to the one host and parses correctly" do
@@ -216,10 +247,9 @@ launched-by-ondemand-a8e85cd4-791d-49fa-8be1-5bd5c1009d70,1569609529,175138" }
             end
         end
 
-        context "When SSH output breaks OOD parsing for card" do
-            let(:owens_remote_host) { opts[:ssh_hosts].first }
-            it "still connects successfully" do
-                allow(Open3).to receive(:capture3).and_return([tmux_broken_output, '', exit_success])
+        context "When SSH output has multiple fields with some being incomplete it" do
+            it "parses and extracts the correct hash." do
+                allow(Open3).to receive(:capture3).and_return([tmux_broken_output_with_many_returned_fields, '', exit_success])
 
                 expect(
                     subject.list_remote_sessions(host: owens_remote_host)


### PR DESCRIPTION
Fixes #297. Still not working in the browser when trying to launch codeserver, and only codeserver gives the issue. 