### PR TITLE
Bugfix/k8s context

### DIFF
--- a/lib/ood_core/job/adapters/kubernetes/batch.rb
+++ b/lib/ood_core/job/adapters/kubernetes/batch.rb
@@ -352,7 +352,7 @@ class OodCore::Job::Adapters::Kubernetes::Batch
     # gke cluster name can probably can differ from what ood calls the cluster
     cmd = "gcloud container clusters get-credentials #{locale} #{cluster}"
     env = { 'KUBECONFIG' => config_file }
-    call(cmd, env)
+    call(cmd, env: env)
   end
 
   def set_context

--- a/spec/job/adapters/kubernetes/batch_spec.rb
+++ b/spec/job/adapters/kubernetes/batch_spec.rb
@@ -1092,7 +1092,7 @@ EOS
       Batch.configure_kube!(config)
     end
 
-    it 'runs the correct gke commans' do
+    it 'runs the correct gke commands' do
       cfg = {
         :auth => {
           :type => 'gke',
@@ -1105,12 +1105,38 @@ EOS
 
       set_cluster = "/usr/bin/kubectl --kubeconfig=~/.gke/oakley.config config set-cluster gke-cluster-oakley " \
         "--server=https://localhost:8080"
-      gcloud = "gcloud auth activate-service-account --key-file=~/.gke/acct.key"
-      # env = {:env  }
+      auth_activate = "gcloud auth activate-service-account --key-file=~/.gke/acct.key"
+      ctr_cluster = "gcloud container clusters get-credentials --region=ohio gke-cluster-oakley"
+      env = env = { 'KUBECONFIG' => '~/.gke/oakley.config' }
 
-      # expect_any_instance_of(Batch).to receive(:call).with(set_cluster)
-      # expect_any_instance_of(Batch).to receive(:call).with(gcloud, { 'KUBECONFIG' => '~/.gke/oakley.config' })
-      # Batch.configure_kube!(cfg)
+      expect_any_instance_of(Batch).to receive(:call).with(set_cluster)
+      expect_any_instance_of(Batch).to receive(:call).with(auth_activate)
+      expect_any_instance_of(Batch).to receive(:call).with(ctr_cluster, env: env)
+      Batch.configure_kube!(cfg)
+    end
+
+    # same as the test above, only using --zone instead of --region
+    it 'zone works in gke' do
+      cfg = {
+        :auth => {
+          :type => 'gke',
+          :zone => 'ohio',
+          :svc_acct_file => '~/.gke/acct.key',
+        },
+        :cluster => 'gke-cluster-oakley',
+        :config_file => '~/.gke/oakley.config',
+      }
+
+      set_cluster = "/usr/bin/kubectl --kubeconfig=~/.gke/oakley.config config set-cluster gke-cluster-oakley " \
+        "--server=https://localhost:8080"
+      auth_activate = "gcloud auth activate-service-account --key-file=~/.gke/acct.key"
+      ctr_cluster = "gcloud container clusters get-credentials --zone=ohio gke-cluster-oakley"
+      env = env = { 'KUBECONFIG' => '~/.gke/oakley.config' }
+
+      expect_any_instance_of(Batch).to receive(:call).with(set_cluster)
+      expect_any_instance_of(Batch).to receive(:call).with(auth_activate)
+      expect_any_instance_of(Batch).to receive(:call).with(ctr_cluster, env: env)
+      Batch.configure_kube!(cfg)
     end
   end
 end


### PR DESCRIPTION
Fixes #227 .  Users will now have to configure a context to get the `--context` flag.  I'm wondering if we want to supply context = cluster if we're using OIDC? I'll have to check the hooks and what sort of assumptions we make if we're using OIDC.


It's a little bigger of a change that I wanted, but here we are. This also fixes a few bugs that, were just there, I'll try to note them where I can.

The idea here is to get an OOD initializer to run this class method (which has tests).

```ruby
Batch.configure_kube!(cfg)
```