### PR TITLE
fix --all-namespaces commands to have -o json before the verb

### DIFF
--- a/lib/ood_core/job/adapters/kubernetes/batch.rb
+++ b/lib/ood_core/job/adapters/kubernetes/batch.rb
@@ -56,10 +56,10 @@ class OodCore::Job::Adapters::Kubernetes::Batch
   end
 
   def info_all(attrs: nil)
-    cmd = if all_namespaces
-            "#{base_cmd} get pods -o json --all-namespaces"
+    cmd = if @all_namespaces
+            "#{base_cmd} -o json get pods --all-namespaces"
           else
-            "#{namespaced_cmd} get pods -o json"
+            "#{namespaced_cmd} -o json get pods"
           end
 
     output = call(cmd)
@@ -248,6 +248,7 @@ class OodCore::Job::Adapters::Kubernetes::Batch
   # and  id=my-pod-id
   def call_json_output(verb, resource, id, stdin: nil)
     cmd = "#{formatted_ns_cmd} #{verb} #{resource} #{id}"
+
     data = call(cmd, stdin: stdin)
     data = data.empty? ? '{}' : data
     json_data = JSON.parse(data, symbolize_names: true)

--- a/spec/job/adapters/kubernetes/batch_spec.rb
+++ b/spec/job/adapters/kubernetes/batch_spec.rb
@@ -914,7 +914,7 @@ EOS
       allow(Open3).to receive(:capture3).with(
         {},
         "/usr/bin/kubectl --kubeconfig=#{ENV['HOME']}/.kube/config " \
-        "--namespace=testuser get pods -o json",
+        "--namespace=testuser -o json get pods",
         stdin_data: ""
       ).and_return(['No resources found in testuser namespace.', '', success])
 
@@ -925,7 +925,7 @@ EOS
     it "throws error up the stack with --all-namespaces" do
       allow(Open3).to receive(:capture3).with(
         {},
-        "/usr/bin/wontwork --kubeconfig=~/kube.config --context=ood-test-cluster get pods -o json --all-namespaces",
+        "/usr/bin/wontwork --kubeconfig=~/kube.config --context=ood-test-cluster -o json get pods --all-namespaces",
         stdin_data: ""
       ).and_return(['', errmsg, failure])
 
@@ -936,7 +936,7 @@ EOS
       allow(Open3).to receive(:capture3).with(
         {},
         "/usr/bin/kubectl --kubeconfig=#{ENV['HOME']}/.kube/config " \
-        "--namespace=testuser get pods -o json",
+        "--namespace=testuser -o json get pods",
         stdin_data: ""
       ).and_return([several_pods, '', success])
 


### PR DESCRIPTION
I noticed in #324 that because we have this toggle here, most calls are`-o json <VERB>` but when we use --all-namespaces it's `<VERB> -o json`.

It's not a functionality thing, just a uniformity thing, all these calls should at least look the same if they're not coming from the same code paths (how to fix so many `call` functions here... is a larger problem).