### PR TITLE
add deep_merge! to hash extensions with the rails license

### DIFF
--- a/RAILS-LICENSE
+++ b/RAILS-LICENSE
@@ -1,0 +1,20 @@
+Copyright (c) 2005-2021 David Heinemeier Hansson
+
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of this software and associated documentation files (the
+"Software"), to deal in the Software without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Software, and to
+permit persons to whom the Software is furnished to do so, subject to
+the following conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/lib/ood_core/job/adapters/kubernetes/helper.rb
+++ b/lib/ood_core/job/adapters/kubernetes/helper.rb
@@ -4,7 +4,9 @@ class OodCore::Job::Adapters::Kubernetes::Helper
   require_relative 'k8s_job_info'
   require 'resolv'
   require 'base64'
-  require 'active_support/core_ext/hash'
+  require 'ood_core/refinements/hash_extensions'
+
+  using OodCore::Refinements::HashExtensions
 
   class K8sDataError < StandardError; end
 

--- a/lib/ood_core/refinements/hash_extensions.rb
+++ b/lib/ood_core/refinements/hash_extensions.rb
@@ -2,6 +2,8 @@ module OodCore
   # Namespace for Ruby refinements
   module Refinements
     # This module provides refinements for manipulating the Ruby {Hash} class.
+    # Some elements have been taken from Rails (https://github.com/rails/rails)
+    # and it's LICENSE has been added as RAILS-LICENSE in the root directory of this project.
     module HashExtensions
       refine Hash do
         # Symbolize the keys in a {Hash}
@@ -27,6 +29,37 @@ module OodCore
         # @see https://apidock.com/rails/Hash/compact
         def compact
           self.select { |_, value| !value.nil? }
+        end
+
+        # Returns a new hash with +self+ and +other_hash+ merged recursively.
+        #
+        #   h1 = { a: true, b: { c: [1, 2, 3] } }
+        #   h2 = { a: false, b: { x: [3, 4, 5] } }
+        #
+        #   h1.deep_merge(h2) # => { a: false, b: { c: [1, 2, 3], x: [3, 4, 5] } }
+        #
+        # Like with Hash#merge in the standard library, a block can be provided
+        # to merge values:
+        #
+        #   h1 = { a: 100, b: 200, c: { c1: 100 } }
+        #   h2 = { b: 250, c: { c1: 200 } }
+        #   h1.deep_merge(h2) { |key, this_val, other_val| this_val + other_val }
+        #   # => { a: 100, b: 450, c: { c1: 300 } }
+        def deep_merge(other_hash, &block)
+          dup.deep_merge!(other_hash, &block)
+        end
+
+        # Same as +deep_merge+, but modifies +self+.
+        def deep_merge!(other_hash, &block)
+          merge!(other_hash) do |key, this_val, other_val|
+            if this_val.is_a?(Hash) && other_val.is_a?(Hash)
+              this_val.deep_merge(other_val, &block)
+            elsif block_given?
+              block.call(key, this_val, other_val)
+            else
+              other_val
+            end
+          end
         end
       end
     end

--- a/ood_core.gemspec
+++ b/ood_core.gemspec
@@ -25,7 +25,6 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency "ood_support", "~> 0.0.2"
   spec.add_runtime_dependency "ffi", "~> 1.9", ">= 1.9.6"
   spec.add_development_dependency "bundler", "~> 2.1"
-  spec.add_runtime_dependency "activesupport", ">= 5.2", "< 6.0"
   spec.add_development_dependency "rake", "~> 13.0.1"
   spec.add_development_dependency "rspec", "~> 3.0"
   spec.add_development_dependency "pry", "~> 0.10"


### PR DESCRIPTION
add deep_merge! to hash extensions with the rails license to get rid of the active support dependency.