### PR TITLE
Make Linux Host adapter delete function more portable

### DIFF
--- a/lib/ood_core/job/adapters/linux_host/launcher.rb
+++ b/lib/ood_core/job/adapters/linux_host/launcher.rb
@@ -73,7 +73,7 @@ class OodCore::Job::Adapters::LinuxHost::Launcher
     # Get the tmux pane PID for the target session
     pane_pid=$(tmux list-panes -aF '\#{session_name} \#{pane_pid}' | grep '#{session_name}' | cut -f 2 -d ' ')
     # Find the Singularity sinit PID child of the pane process
-    pane_sinit_pid=$(pstree -p -l "$pane_pid" | grep -o 'sinit([[:digit:]]*' | grep -o '[[:digit:]]*')
+    pane_sinit_pid=$(pstree -p -l "$pane_pid" | egrep -o 'sinit[(][[:digit:]]*|shim-init[(][[:digit:]]*' | grep -o '[[:digit:]]*') 
     # Kill sinit which stops both Singularity-based processes and the tmux session
     kill "$pane_sinit_pid"
     SCRIPT


### PR DESCRIPTION
While making apps that run on an old Fedora 27 box, ran into an issue where the sinit process is actually named shim-init. This was failing the original grep in the kill function and apps could not be killed. 

Switched the grep to an egrep, added the shim-init as an or option and used `[]` to escape the ( as older egreps can have problems with the standard \( escape.

Commit comment:
extended Linux Host adapter kill function grep to also find processes under the name shim-init and not just sinit