### PR TITLE
Improved pod security

### DIFF
--- a/lib/ood_core/job/adapters/kubernetes/templates/pod.yml.erb
+++ b/lib/ood_core/job/adapters/kubernetes/templates/pod.yml.erb
@@ -106,7 +106,9 @@ spec:
       allowPrivilegeEscalation: false
       capabilities:
         drop:
-        - all
+        - ALL
+      seccompProfile:
+        type: RuntimeDefault
       privileged: false
   <%- unless spec.init_containers.empty? -%>
   initContainers:
@@ -152,7 +154,9 @@ spec:
       allowPrivilegeEscalation: false
       capabilities:
         drop:
-        - all
+        - ALL
+      seccompProfile:
+        type: RuntimeDefault
       privileged: false
   <%- end # init container loop -%>
   <%- end # if init containers -%>

--- a/spec/fixtures/output/k8s/pod_yml_extra_groups.yml
+++ b/spec/fixtures/output/k8s/pod_yml_extra_groups.yml
@@ -80,7 +80,9 @@ spec:
       allowPrivilegeEscalation: false
       capabilities:
         drop:
-        - all
+        - ALL
+      seccompProfile:
+        type: RuntimeDefault
       privileged: false
   initContainers:
   - name: "init-1"
@@ -120,7 +122,9 @@ spec:
       allowPrivilegeEscalation: false
       capabilities:
         drop:
-        - all
+        - ALL
+      seccompProfile:
+        type: RuntimeDefault
       privileged: false
   volumes:
   - name: configmap-volume

--- a/spec/fixtures/output/k8s/pod_yml_from_all_configs.yml
+++ b/spec/fixtures/output/k8s/pod_yml_from_all_configs.yml
@@ -89,7 +89,9 @@ spec:
       allowPrivilegeEscalation: false
       capabilities:
         drop:
-        - all
+        - ALL
+      seccompProfile:
+        type: RuntimeDefault
       privileged: false
   initContainers:
   - name: "init-1"
@@ -135,7 +137,9 @@ spec:
       allowPrivilegeEscalation: false
       capabilities:
         drop:
-        - all
+        - ALL
+      seccompProfile:
+        type: RuntimeDefault
       privileged: false
   volumes:
   - name: configmap-volume

--- a/spec/fixtures/output/k8s/pod_yml_from_defaults.yml
+++ b/spec/fixtures/output/k8s/pod_yml_from_defaults.yml
@@ -80,7 +80,9 @@ spec:
       allowPrivilegeEscalation: false
       capabilities:
         drop:
-        - all
+        - ALL
+      seccompProfile:
+        type: RuntimeDefault
       privileged: false
   initContainers:
   - name: "init-1"
@@ -120,7 +122,9 @@ spec:
       allowPrivilegeEscalation: false
       capabilities:
         drop:
-        - all
+        - ALL
+      seccompProfile:
+        type: RuntimeDefault
       privileged: false
   volumes:
   - name: configmap-volume

--- a/spec/fixtures/output/k8s/pod_yml_no_configmaps.yml
+++ b/spec/fixtures/output/k8s/pod_yml_no_configmaps.yml
@@ -78,7 +78,9 @@ spec:
       allowPrivilegeEscalation: false
       capabilities:
         drop:
-        - all
+        - ALL
+      seccompProfile:
+        type: RuntimeDefault
       privileged: false
   initContainers:
   - name: "init-1"
@@ -118,7 +120,9 @@ spec:
       allowPrivilegeEscalation: false
       capabilities:
         drop:
-        - all
+        - ALL
+      seccompProfile:
+        type: RuntimeDefault
       privileged: false
   volumes:
   - name: configmap-volume

--- a/spec/fixtures/output/k8s/pod_yml_no_init_container.yml
+++ b/spec/fixtures/output/k8s/pod_yml_no_init_container.yml
@@ -80,7 +80,9 @@ spec:
       allowPrivilegeEscalation: false
       capabilities:
         drop:
-        - all
+        - ALL
+      seccompProfile:
+        type: RuntimeDefault
       privileged: false
   volumes:
   - name: configmap-volume

--- a/spec/fixtures/output/k8s/pod_yml_no_mounts.yml
+++ b/spec/fixtures/output/k8s/pod_yml_no_mounts.yml
@@ -78,7 +78,9 @@ spec:
       allowPrivilegeEscalation: false
       capabilities:
         drop:
-        - all
+        - ALL
+      seccompProfile:
+        type: RuntimeDefault
       privileged: false
   initContainers:
   - name: "init-1"
@@ -115,7 +117,9 @@ spec:
       allowPrivilegeEscalation: false
       capabilities:
         drop:
-        - all
+        - ALL
+      seccompProfile:
+        type: RuntimeDefault
       privileged: false
   volumes:
   - name: configmap-volume

--- a/spec/fixtures/output/k8s/pod_yml_no_mounts_no_configmaps.yml
+++ b/spec/fixtures/output/k8s/pod_yml_no_mounts_no_configmaps.yml
@@ -76,7 +76,9 @@ spec:
       allowPrivilegeEscalation: false
       capabilities:
         drop:
-        - all
+        - ALL
+      seccompProfile:
+        type: RuntimeDefault
       privileged: false
   initContainers:
   - name: "init-1"
@@ -113,7 +115,9 @@ spec:
       allowPrivilegeEscalation: false
       capabilities:
         drop:
-        - all
+        - ALL
+      seccompProfile:
+        type: RuntimeDefault
       privileged: false
   volumes:
   - name: configmap-volume

--- a/spec/fixtures/output/k8s/pod_yml_subpath_configmap.yml
+++ b/spec/fixtures/output/k8s/pod_yml_subpath_configmap.yml
@@ -84,7 +84,9 @@ spec:
       allowPrivilegeEscalation: false
       capabilities:
         drop:
-        - all
+        - ALL
+      seccompProfile:
+        type: RuntimeDefault
       privileged: false
   initContainers:
   - name: "init-1"
@@ -126,7 +128,9 @@ spec:
       allowPrivilegeEscalation: false
       capabilities:
         drop:
-        - all
+        - ALL
+      seccompProfile:
+        type: RuntimeDefault
       privileged: false
   volumes:
   - name: configmap-volume


### PR DESCRIPTION
Using Kyverno 1.6.0 pod security standards that mimic Kubernetes pod security standards.  We do have to filter out a few that simply can't support, like we do have to allow hostPath, but these are simple security changes to be able to conform to these new policies.



┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201735133575781/1201901746971618) by [Unito](https://www.unito.io)
