### PR TITLE
publish yardoc pages to gh-pages

### DIFF
--- a/.github/workflows/publish_yarndoc.yml
+++ b/.github/workflows/publish_yarndoc.yml
@@ -1,11 +1,7 @@
 name: Publish yarndoc
 
 on:
-  workflow_dispatch:
   push:
-    branches:
-      - master
-  pull_request:
     branches:
       - master
 

--- a/.github/workflows/publish_yarndoc.yml
+++ b/.github/workflows/publish_yarndoc.yml
@@ -18,6 +18,8 @@ jobs:
 
       - name: Setup Ruby using Bundler
         uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: '3.0'
 
       - name: install gems
         run: bundle install && gem install yardoc

--- a/.github/workflows/publish_yarndoc.yml
+++ b/.github/workflows/publish_yarndoc.yml
@@ -32,7 +32,7 @@ jobs:
           GIT_AUTHOR_NAME: "oscwiag"
           GIT_AUTHOR_EMAIL: "oscwiag@gmail.com"
         run: |
-          git clone https://{{ secrets.OSC_WIAG_PUB_REPO_TOKEN }}@github.com/osc/ood_core.git /tmp/core
+          git clone https://${{ secrets.OSC_WIAG_PUB_REPO_TOKEN }}@github.com/osc/ood_core.git /tmp/core
           cd /tmp/core
           git checkout gh-pages
           mv /tmp/docs .

--- a/.github/workflows/publish_yarndoc.yml
+++ b/.github/workflows/publish_yarndoc.yml
@@ -35,7 +35,7 @@ jobs:
           git clone https://${{ secrets.OSC_WIAG_PUB_REPO_TOKEN }}@github.com/osc/ood_core.git /tmp/core
           cd /tmp/core
           git checkout gh-pages
-          mv /tmp/docs .
+          mv --force /tmp/docs .
           git commit -m 'new docs'
           git push
           

--- a/.github/workflows/publish_yarndoc.yml
+++ b/.github/workflows/publish_yarndoc.yml
@@ -22,7 +22,7 @@ jobs:
           ruby-version: '3.0'
 
       - name: install gems
-        run: bundle install && gem install yardoc
+        run: bundle install && gem install yard
 
       - name: generate documentation
         run: yardoc --output-dir docs/

--- a/.github/workflows/publish_yarndoc.yml
+++ b/.github/workflows/publish_yarndoc.yml
@@ -29,9 +29,9 @@ jobs:
 
       - name: save docs and publish
         run: |
-          git clone https://${{ secrets.OSC_WIAG_PUB_REPO_TOKEN }}@github.com/osc/ood_core.git /tmp/core
-          git config --global user.name "oscwiag"
-          git config --global user.email "oscwiag@gmail.com"
+          git clone https://${{ secrets.OSC_ROBOT_GH_PUB_REPO_TOKEN }}@github.com/osc/ood_core.git /tmp/core
+          git config --global user.name "${{ secrets.OSC_ROBOT_GH_USER }}"
+          git config --global user.email "${{ secrets.OSC_ROBOT_GH_USER_EMAIL }}"
           cd /tmp/core
           git checkout gh-pages
           rm -rf docs/

--- a/.github/workflows/publish_yarndoc.yml
+++ b/.github/workflows/publish_yarndoc.yml
@@ -35,7 +35,8 @@ jobs:
           git clone https://${{ secrets.OSC_WIAG_PUB_REPO_TOKEN }}@github.com/osc/ood_core.git /tmp/core
           cd /tmp/core
           git checkout gh-pages
-          mv --force /tmp/docs .
+          rm -rf docs/
+          mv /tmp/docs .
           git commit -m 'new docs'
           git push
           

--- a/.github/workflows/publish_yarndoc.yml
+++ b/.github/workflows/publish_yarndoc.yml
@@ -1,0 +1,36 @@
+name: Publish yarndoc
+
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - master
+  pull_request:
+    branches:
+      - master
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+      - name: checkout
+        uses: actions/checkout@v2
+
+      - name: Setup Ruby using Bundler
+        uses: ruby/setup-ruby@v1
+
+      - name: install gems
+        run: bundle install && gem install yardoc
+
+      - name: generate documentation
+        run: yardoc --output-dir docs/
+
+      - name: save docs and publish
+        env:
+          GIT_AUTHOR_NAME: "oscwiag"
+          GIT_AUTHOR_EMAIL: "oscwiag@gmail.com"
+        run: |
+          git checkout gh-pages
+          git add docs/
+          git commit -m 'new docs'
+          git push https://{{ secrets.OSC_WIAG_PUB_REPO_TOKEN }}@github.com/osc/ood_core.git

--- a/.github/workflows/publish_yarndoc.yml
+++ b/.github/workflows/publish_yarndoc.yml
@@ -25,14 +25,17 @@ jobs:
         run: bundle install && gem install yard
 
       - name: generate documentation
-        run: yardoc --output-dir docs/
+        run: yardoc --output-dir /tmp/docs/
 
       - name: save docs and publish
         env:
           GIT_AUTHOR_NAME: "oscwiag"
           GIT_AUTHOR_EMAIL: "oscwiag@gmail.com"
         run: |
+          git clone https://{{ secrets.OSC_WIAG_PUB_REPO_TOKEN }}@github.com/osc/ood_core.git /tmp/core
+          cd /tmp/core
           git checkout gh-pages
-          git add docs/
+          mv /tmp/docs .
           git commit -m 'new docs'
-          git push https://{{ secrets.OSC_WIAG_PUB_REPO_TOKEN }}@github.com/osc/ood_core.git
+          git push
+          

--- a/.github/workflows/publish_yarndoc.yml
+++ b/.github/workflows/publish_yarndoc.yml
@@ -28,15 +28,15 @@ jobs:
         run: yardoc --output-dir /tmp/docs/
 
       - name: save docs and publish
-        env:
-          GIT_AUTHOR_NAME: "oscwiag"
-          GIT_AUTHOR_EMAIL: "oscwiag@gmail.com"
         run: |
           git clone https://${{ secrets.OSC_WIAG_PUB_REPO_TOKEN }}@github.com/osc/ood_core.git /tmp/core
+          git config --global user.name "oscwiag"
+          git config --global user.email "oscwiag@gmail.com"
           cd /tmp/core
           git checkout gh-pages
           rm -rf docs/
           mv /tmp/docs .
+          git add docs/
           git commit -m 'new docs'
           git push
           

--- a/.gitignore
+++ b/.gitignore
@@ -51,3 +51,7 @@ Gemfile.lock
 
 # SSHFS temp files
 ._*
+
+# docs are only held in the gh-pages branch
+/docs/*
+!/docs/.keep


### PR DESCRIPTION
Fixes #226 by adding a github action to publish the yardocs every push to master.



┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1135148780858012/1202701632679248) by [Unito](https://www.unito.io)
