### PR TITLE
add k8s ability to read many items from secrets

### DIFF
--- a/lib/ood_core/job/adapters/kubernetes/helper.rb
+++ b/lib/ood_core/job/adapters/kubernetes/helper.rb
@@ -195,10 +195,14 @@ class OodCore::Job::Adapters::Kubernetes::Helper
   end
 
   def secret_info_from_json(json_data)
-    raw = json_data.dig(:data, :password)
-    { ood_connection_info: { password: Base64.decode64(raw) } }
-  rescue
-    {}
+    data = json_data.to_h[:data] || {}
+
+    info = data.symbolize_keys.each_with_object({}) do |data_kv, hash|
+      hash[data_kv[0]] = Base64.decode64(data_kv[1])
+    rescue
+      next
+    end
+    { ood_connection_info: info }
   end
 
   def dispatch_time(json_data)


### PR DESCRIPTION
Fixes #744 such that k8s jobs can add as many secrets as they like and we'll read them all back as key value pairs.



┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1135148780858012/1203058034806804) by [Unito](https://www.unito.io)
