### PR TITLE
account for newlines in slurms account api

### DIFF
--- a/lib/ood_core/job/adapters/slurm.rb
+++ b/lib/ood_core/job/adapters/slurm.rb
@@ -186,13 +186,13 @@ module OodCore
             [].tap do |accts|
               call('sacctmgr', *args).each_line do |line|
                 acct, cluster, queue, qos = line.split('|')
-                next if acct.nil?
+                next if acct.nil? || acct.chomp.empty?
 
                 args = {
                   name: acct,
                   qos: qos.to_s.chomp.split(','),
                   cluster: cluster,
-                  queue: queue.empty? ? nil : queue
+                  queue: queue.to_s.empty? ? nil : queue
                 }
                 info = OodCore::Job::AccountInfo.new(**args) unless acct.nil?
                 accts << info unless acct.nil?

--- a/spec/fixtures/output/slurm/sacctmgr_show_accts.txt
+++ b/spec/fixtures/output/slurm/sacctmgr_show_accts.txt
@@ -22,3 +22,6 @@ pas2051|pitzer||pitzer-default
 pas1871|pitzer||pitzer-default
 pas1754|pitzer||pitzer-default
 pas1604|pitzer||pitzer-default
+
+
+


### PR DESCRIPTION
I've been getting failures around `undefined method `empty?' for nil:NilClass` queue here, so this adds a little safety here.

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1135148780858012/1203821081389675) by [Unito](https://www.unito.io)
