### PR TITLE
apptainer regex needs * to pick up all characters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -487,8 +487,8 @@ Functionally the same as [0.17.3] but with some CI updates.
 - Initial release!
 
 [Unreleased]: https://github.com/OSC/ood_core/compare/v0.23.2...HEAD
-[0.23.2]: https://github.com/OSC/ood_core/compare/v0.22.0...v0.23.0
-[0.23.1]: https://github.com/OSC/ood_core/compare/v0.22.0...v0.23.0
+[0.23.2]: https://github.com/OSC/ood_core/compare/v0.23.1...v0.23.2
+[0.23.1]: https://github.com/OSC/ood_core/compare/v0.23.0...v0.23.1
 [0.23.0]: https://github.com/OSC/ood_core/compare/v0.22.0...v0.23.0
 [0.22.0]: https://github.com/OSC/ood_core/compare/v0.21.0...v0.22.0
 [0.21.0]: https://github.com/OSC/ood_core/compare/v0.20.2...v0.21.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## [0.23.2] - 02-02-2023
+
+### Fixed
+
+- The linux host adapter should correctly extract the full apptainer pid in [794](https://github.com/OSC/ood_core/pull/794).
+
+
 ## [0.23.1] - 02-01-2023
 
 ### Fixed
@@ -479,7 +486,8 @@ Functionally the same as [0.17.3] but with some CI updates.
 ### Added
 - Initial release!
 
-[Unreleased]: https://github.com/OSC/ood_core/compare/v0.23.1...HEAD
+[Unreleased]: https://github.com/OSC/ood_core/compare/v0.23.2...HEAD
+[0.23.2]: https://github.com/OSC/ood_core/compare/v0.22.0...v0.23.0
 [0.23.1]: https://github.com/OSC/ood_core/compare/v0.22.0...v0.23.0
 [0.23.0]: https://github.com/OSC/ood_core/compare/v0.22.0...v0.23.0
 [0.22.0]: https://github.com/OSC/ood_core/compare/v0.21.0...v0.22.0

--- a/lib/ood_core/job/adapters/linux_host/launcher.rb
+++ b/lib/ood_core/job/adapters/linux_host/launcher.rb
@@ -73,7 +73,7 @@ class OodCore::Job::Adapters::LinuxHost::Launcher
     # Get the tmux pane PID for the target session
     pane_pid=$(tmux list-panes -aF '\#{session_name} \#{pane_pid}' | grep '#{session_name}' | cut -f 2 -d ' ')
     # Find the Singularity sinit PID child of the pane process
-    pane_sinit_pid=$(pstree -p -l "$pane_pid" | egrep -o 'sinit[(][[:digit:]]*|shim-init[(][[:digit:]]|appinit[(][[:digit:]]' | grep -o '[[:digit:]]*')
+    pane_sinit_pid=$(pstree -p -l "$pane_pid" | egrep -o 'sinit[(][[:digit:]]*|shim-init[(][[:digit:]]|appinit[(][[:digit:]]*' | grep -o '[[:digit:]]*')
     # Kill sinit which stops both Singularity-based processes and the tmux session
     kill "$pane_sinit_pid"
     SCRIPT

--- a/lib/ood_core/version.rb
+++ b/lib/ood_core/version.rb
@@ -1,4 +1,4 @@
 module OodCore
   # The current version of {OodCore}
-  VERSION = "0.23.1"
+  VERSION = "0.23.2"
 end


### PR DESCRIPTION
apptainer regex needs * to pick up all characters, otherwise it's just returning the very first character so folks end up trying to kill pid 3 instead of say pid 301297.

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1135148780858012/1203887738496722) by [Unito](https://www.unito.io)
