### PR TITLE
ACLs to use block & allowlists

### DIFF
--- a/lib/ood_core/acl/adapters/group.rb
+++ b/lib/ood_core/acl/adapters/group.rb
@@ -8,20 +8,21 @@ module OodCore
       # Build the group acl adapter from a configuration
       # @param config [#to_h] the configuration for an acl adapter
       # @option config [Array<#to_s>] :groups The list of groups
-      # @option config [#to_s] :type ('whitelist') The type of ACL ('whitelist' or 'blacklist')
+      # @option config [#to_s] :type ('allowlist') The type of ACL ('allowlist' or 'blocklist')
       def self.build_group(config)
         c = config.to_h.symbolize_keys
 
         groups = c.fetch(:groups) { raise ArgumentError, "No groups specified. Missing argument: groups" }.map(&:to_s)
         acl = OodSupport::ACL.new(entries: groups.map { |g| OodSupport::ACLEntry.new principle: g })
 
-        type   = c.fetch(:type, "whitelist").to_s
-        if type == "whitelist"
+        type = c.fetch(:type, 'allowlist').to_s
+        case type
+        when 'allowlist', 'whitelist'
           allow = true
-        elsif type == "blacklist"
+        when 'blocklist', 'blacklist'
           allow = false
         else
-          raise ArgumentError, "Invalid type specified. Valid types: whitelist, blacklist"
+          raise ArgumentError, 'Invalid type specified. Valid types: allowlist, blocklist'
         end
 
         Adapters::Group.new(acl: acl, allow: allow)

--- a/lib/ood_core/clusters.rb
+++ b/lib/ood_core/clusters.rb
@@ -90,7 +90,7 @@ module OodCore
                 {
                   adapter: "group",
                   groups: h["data"]["groups"],
-                  type: h["data"]["allow"] ? "whitelist" : "blacklist"
+                  type: h["data"]["allow"] ? 'allowlist' : 'blocklist'
                 }
               end
             end

--- a/spec/acl/adapters/group_spec.rb
+++ b/spec/acl/adapters/group_spec.rb
@@ -15,11 +15,6 @@ describe OodCore::Acl::Adapters::Group do
     end
   end
 
-  # groups:
-  # - "cluster_users"
-  # - "other_users_of_the_cluster"
-  # type: "whitelist"
-
   describe '#allow' do
     context 'when allowlist is provided' do
       subject { build_group_acl({ groups: ['group-a', 'group-x'], type: 'allowlist' }) }

--- a/spec/acl/adapters/group_spec.rb
+++ b/spec/acl/adapters/group_spec.rb
@@ -1,0 +1,80 @@
+require 'spec_helper'
+require 'ood_core/acl/adapters/group'
+
+describe OodCore::Acl::Adapters::Group do
+
+  def build_group_acl(opts = {})
+    OodCore::Acl::Factory.build_group(opts)
+  end
+
+  describe "#new" do
+    context 'when nothing is provided' do
+      it 'raises an error' do
+        expect { subject }.to raise_error(ArgumentError)
+      end
+    end
+  end
+
+  # groups:
+  # - "cluster_users"
+  # - "other_users_of_the_cluster"
+  # type: "whitelist"
+
+  describe '#allow' do
+    context 'when allowlist is provided' do
+      subject { build_group_acl({ groups: ['group-a', 'group-x'], type: 'allowlist' }) }
+
+      it 'allows users in that group' do
+        allow_any_instance_of(OodSupport::User).to receive(:groups).and_return(['group-a', 'group-b'])
+        expect(subject.allow?).to eql(true)
+      end
+
+      it 'blocks uses not in that group' do
+        allow_any_instance_of(OodSupport::User).to receive(:groups).and_return(['group-c', 'group-d'])
+        expect(subject.allow?).to eql(false)
+      end
+    end
+
+    context 'when blocklist is provided' do
+      subject { build_group_acl({ groups: ['group-a', 'group-x'], type: 'blocklist' }) }
+
+      it 'blocks users in that group' do
+        allow_any_instance_of(OodSupport::User).to receive(:groups).and_return(['group-a', 'group-b'])
+        expect(subject.allow?).to eql(false)
+      end
+
+      it 'allows uses not in that group' do
+        allow_any_instance_of(OodSupport::User).to receive(:groups).and_return(['group-c', 'group-d'])
+        expect(subject.allow?).to eql(true)
+      end
+    end
+
+    context 'when whitelist is provided' do
+      subject { build_group_acl({ groups: ['group-a', 'group-x'], type: 'whitelist' }) }
+
+      it 'allows users in that group' do
+        allow_any_instance_of(OodSupport::User).to receive(:groups).and_return(['group-a', 'group-b'])
+        expect(subject.allow?).to eql(true)
+      end
+
+      it 'blocks uses not in that group' do
+        allow_any_instance_of(OodSupport::User).to receive(:groups).and_return(['group-c', 'group-d'])
+        expect(subject.allow?).to eql(false)
+      end
+    end
+
+    context 'when blacklist is provided' do
+      subject { build_group_acl({ groups: ['group-a', 'group-x'], type: 'blacklist' }) }
+
+      it 'blocks users in that group' do
+        allow_any_instance_of(OodSupport::User).to receive(:groups).and_return(['group-a', 'group-b'])
+        expect(subject.allow?).to eql(false)
+      end
+
+      it 'allows uses not in that group' do
+        allow_any_instance_of(OodSupport::User).to receive(:groups).and_return(['group-c', 'group-d'])
+        expect(subject.allow?).to eql(true)
+      end
+    end
+  end
+end


### PR DESCRIPTION
ACLs to use block & allowlists instead of white & black lists. This is still backward compatible and should be for some time after we update the 2.1 documentation.

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1135148780858012/1203923040787317) by [Unito](https://www.unito.io)
