### PR TITLE
Added Functionality to support Non-Standard SSH Port in the Adapters.

### DIFF
--- a/lib/ood_core/job/adapters/helper.rb
+++ b/lib/ood_core/job/adapters/helper.rb
@@ -26,7 +26,7 @@ module OodCore
           return cmd, cmd_args if submit_host.to_s.empty?
 
           check_host = strict_host_checking ? "yes" : "no"
-          args = ['-p', ENV["OOD_SSH_PORT"].nil? ? 22 : ENV["OOD_SSH_PORT"], '-o', 'BatchMode=yes', '-o', 'UserKnownHostsFile=/dev/null', '-o', "StrictHostKeyChecking=#{check_host}", "#{submit_host}"]
+          args = ['-p', ENV["OOD_SSH_PORT"].nil? ? "22" : "#{ENV['OOD_SSH_PORT']}", '-o', 'BatchMode=yes', '-o', 'UserKnownHostsFile=/dev/null', '-o', "StrictHostKeyChecking=#{check_host}", "#{submit_host}"]
           env.each{|key, value| args.push("export #{key}=#{value};")}
 
           return 'ssh', args + [cmd] + cmd_args

--- a/lib/ood_core/job/adapters/helper.rb
+++ b/lib/ood_core/job/adapters/helper.rb
@@ -26,7 +26,7 @@ module OodCore
           return cmd, cmd_args if submit_host.to_s.empty?
 
           check_host = strict_host_checking ? "yes" : "no"
-          args = ['-o', 'BatchMode=yes', '-o', 'UserKnownHostsFile=/dev/null', '-o', "StrictHostKeyChecking=#{check_host}", "#{submit_host}"]
+          args = ['-p', ENV["OOD_SSH_PORT"].nil? ? 22 : ENV["OOD_SSH_PORT"], '-o', 'BatchMode=yes', '-o', 'UserKnownHostsFile=/dev/null', '-o', "StrictHostKeyChecking=#{check_host}", "#{submit_host}"]
           env.each{|key, value| args.push("export #{key}=#{value};")}
 
           return 'ssh', args + [cmd] + cmd_args

--- a/lib/ood_core/job/adapters/helper.rb
+++ b/lib/ood_core/job/adapters/helper.rb
@@ -26,11 +26,20 @@ module OodCore
           return cmd, cmd_args if submit_host.to_s.empty?
 
           check_host = strict_host_checking ? "yes" : "no"
-          args = ['-p', ENV["OOD_SSH_PORT"].nil? ? "22" : "#{ENV['OOD_SSH_PORT']}", '-o', 'BatchMode=yes', '-o', 'UserKnownHostsFile=/dev/null', '-o', "StrictHostKeyChecking=#{check_host}", "#{submit_host}"]
+          
+          # Have to OodCore::Job::Adapters::Helper.ssh_port instead of self.ssh_port due to test failure
+          args = ['-p', OodCore::Job::Adapters::Helper.ssh_port, '-o', 'BatchMode=yes', '-o', 'UserKnownHostsFile=/dev/null', '-o', "StrictHostKeyChecking=#{check_host}", "#{submit_host}"]
           env.each{|key, value| args.push("export #{key}=#{value};")}
 
           return 'ssh', args + [cmd] + cmd_args
         end
+
+        # Allows for Non-Standard Port usage in ssh commands
+        # To set ENV["OOD_SSH_PORT"], add assignment in /etc/ood/config/nginx_stage.yml
+        def self.ssh_port
+          return ENV["OOD_SSH_PORT"].nil? ? "22" : "#{ENV['OOD_SSH_PORT'].to_i.to_s}"
+        end
+
       end
     end
   end

--- a/lib/ood_core/job/adapters/linux_host/launcher.rb
+++ b/lib/ood_core/job/adapters/linux_host/launcher.rb
@@ -58,7 +58,6 @@ class OodCore::Job::Adapters::LinuxHost::Launcher
   # @param script [OodCore::Job::Script] The script object defining the work
   def start_remote_session(script)
     cmd = ssh_cmd(submit_host(script), ['/usr/bin/env', 'bash'])
-
     session_name = unique_session_name
     output = call(*cmd, stdin: wrapped_script(script, session_name))
     hostname = parse_hostname(output)
@@ -122,15 +121,18 @@ class OodCore::Job::Adapters::LinuxHost::Launcher
   # @param destination_host [#to_s] the destination host you wish to ssh into
   # @param cmd [Array<#to_s>] the command to be executed on the destination host
   def ssh_cmd(destination_host, cmd)
+
     if strict_host_checking
       [
         'ssh', '-t',
+        '-p', ENV["OOD_SSH_PORT"].nil? ? 22 : ENV["OOD_SSH_PORT"],
         '-o', 'BatchMode=yes',
         "#{username}@#{destination_host}"
       ].concat(cmd)
     else
       [
         'ssh', '-t',
+        '-p', ENV["OOD_SSH_PORT"].nil? ? 22 : ENV["OOD_SSH_PORT"],
         '-o', 'BatchMode=yes',
         '-o', 'UserKnownHostsFile=/dev/null',
         '-o', 'StrictHostKeyChecking=no',

--- a/lib/ood_core/job/adapters/linux_host/launcher.rb
+++ b/lib/ood_core/job/adapters/linux_host/launcher.rb
@@ -122,6 +122,8 @@ class OodCore::Job::Adapters::LinuxHost::Launcher
   # @param cmd [Array<#to_s>] the command to be executed on the destination host
   def ssh_cmd(destination_host, cmd)
 
+    # To set ENV["OOD_SSH_PORT"], add assignment in /etc/ood/config/nginx_stage.yml
+
     if strict_host_checking
       [
         'ssh', '-t',
@@ -293,4 +295,5 @@ class OodCore::Job::Adapters::LinuxHost::Launcher
       line.match(/^(([\w+]|[a-zA-Z0-9][\w*-]*\.))*$/)
     end.compact.last.to_s
   end
+
 end

--- a/lib/ood_core/job/adapters/linux_host/launcher.rb
+++ b/lib/ood_core/job/adapters/linux_host/launcher.rb
@@ -125,14 +125,14 @@ class OodCore::Job::Adapters::LinuxHost::Launcher
     if strict_host_checking
       [
         'ssh', '-t',
-        '-p', ENV["OOD_SSH_PORT"].nil? ? 22 : ENV["OOD_SSH_PORT"],
+        '-p', ENV["OOD_SSH_PORT"].nil? ? "22" : "#{ENV['OOD_SSH_PORT']}",
         '-o', 'BatchMode=yes',
         "#{username}@#{destination_host}"
       ].concat(cmd)
     else
       [
         'ssh', '-t',
-        '-p', ENV["OOD_SSH_PORT"].nil? ? 22 : ENV["OOD_SSH_PORT"],
+        '-p', ENV["OOD_SSH_PORT"].nil? ? "22" : "#{ENV['OOD_SSH_PORT']}",
         '-o', 'BatchMode=yes',
         '-o', 'UserKnownHostsFile=/dev/null',
         '-o', 'StrictHostKeyChecking=no',

--- a/lib/ood_core/job/adapters/linux_host/launcher.rb
+++ b/lib/ood_core/job/adapters/linux_host/launcher.rb
@@ -122,19 +122,17 @@ class OodCore::Job::Adapters::LinuxHost::Launcher
   # @param cmd [Array<#to_s>] the command to be executed on the destination host
   def ssh_cmd(destination_host, cmd)
 
-    # To set ENV["OOD_SSH_PORT"], add assignment in /etc/ood/config/nginx_stage.yml
-
     if strict_host_checking
       [
         'ssh', '-t',
-        '-p', ENV["OOD_SSH_PORT"].nil? ? "22" : "#{ENV['OOD_SSH_PORT']}",
+        '-p', OodCore::Job::Adapters::Helper.ssh_port,
         '-o', 'BatchMode=yes',
         "#{username}@#{destination_host}"
       ].concat(cmd)
     else
       [
         'ssh', '-t',
-        '-p', ENV["OOD_SSH_PORT"].nil? ? "22" : "#{ENV['OOD_SSH_PORT']}",
+        '-p', OodCore::Job::Adapters::Helper.ssh_port,
         '-o', 'BatchMode=yes',
         '-o', 'UserKnownHostsFile=/dev/null',
         '-o', 'StrictHostKeyChecking=no',

--- a/lib/ood_core/job/adapters/systemd/launcher.rb
+++ b/lib/ood_core/job/adapters/systemd/launcher.rb
@@ -104,14 +104,14 @@ class OodCore::Job::Adapters::LinuxSystemd::Launcher
     if strict_host_checking
       [
         'ssh', '-t',
-        '-p', ENV["OOD_SSH_PORT"].nil? "22" : "#{ENV['OOD_SSH_PORT']}",
+        '-p', OodCore::Job::Adapters::Helper.ssh_port,
         '-o', 'BatchMode=yes',
         "#{username}@#{destination_host}"
       ].concat(cmd)
     else
       [
         'ssh', '-t',
-        '-p', ENV["OOD_SSH_PORT"].nil? ? "22" : "#{ENV['OOD_SSH_PORT']}",
+        '-p', OodCore::Job::Adapters::Helper.ssh_port,
         '-o', 'BatchMode=yes',
         '-o', 'UserKnownHostsFile=/dev/null',
         '-o', 'StrictHostKeyChecking=no',

--- a/lib/ood_core/job/adapters/systemd/launcher.rb
+++ b/lib/ood_core/job/adapters/systemd/launcher.rb
@@ -104,12 +104,14 @@ class OodCore::Job::Adapters::LinuxSystemd::Launcher
     if strict_host_checking
       [
         'ssh', '-t',
+        '-p', ENV["OOD_SSH_PORT"].nil? ? 22 : ENV["OOD_SSH_PORT"],
         '-o', 'BatchMode=yes',
         "#{username}@#{destination_host}"
       ].concat(cmd)
     else
       [
         'ssh', '-t',
+        '-p', ENV["OOD_SSH_PORT"].nil? ? 22 : ENV["OOD_SSH_PORT"],
         '-o', 'BatchMode=yes',
         '-o', 'UserKnownHostsFile=/dev/null',
         '-o', 'StrictHostKeyChecking=no',

--- a/lib/ood_core/job/adapters/systemd/launcher.rb
+++ b/lib/ood_core/job/adapters/systemd/launcher.rb
@@ -104,14 +104,14 @@ class OodCore::Job::Adapters::LinuxSystemd::Launcher
     if strict_host_checking
       [
         'ssh', '-t',
-        '-p', ENV["OOD_SSH_PORT"].nil? ? 22 : ENV["OOD_SSH_PORT"],
+        '-p', ENV["OOD_SSH_PORT"].nil? "22" : "#{ENV['OOD_SSH_PORT']}",
         '-o', 'BatchMode=yes',
         "#{username}@#{destination_host}"
       ].concat(cmd)
     else
       [
         'ssh', '-t',
-        '-p', ENV["OOD_SSH_PORT"].nil? ? 22 : ENV["OOD_SSH_PORT"],
+        '-p', ENV["OOD_SSH_PORT"].nil? ? "22" : "#{ENV['OOD_SSH_PORT']}",
         '-o', 'BatchMode=yes',
         '-o', 'UserKnownHostsFile=/dev/null',
         '-o', 'StrictHostKeyChecking=no',

--- a/spec/job/adapters/helper_spec.rb
+++ b/spec/job/adapters/helper_spec.rb
@@ -51,7 +51,7 @@ describe OodCore::Job::Adapters::Helper do
       let(:submit_host) { "owens.osc.edu" }
 
       it "returns the ssh wrapped command" do 
-        expect(helper.ssh_wrap(submit_host, cmd, cmd_args)).to eq(["ssh", ["-p", ENV["OOD_SSH_PORT"].nil? ? 22 : ENV["OOD_SSH_PORT"], "-o", "BatchMode=yes", "-o", "UserKnownHostsFile=/dev/null", "-o", "StrictHostKeyChecking=yes", "owens.osc.edu", "sbatch", "-J", "Job Name"]])
+        expect(helper.ssh_wrap(submit_host, cmd, cmd_args)).to eq(["ssh", ["-p", ENV["OOD_SSH_PORT"].nil? ? "22" : "#{ENV['OOD_SSH_PORT']}", "-o", "BatchMode=yes", "-o", "UserKnownHostsFile=/dev/null", "-o", "StrictHostKeyChecking=yes", "owens.osc.edu", "sbatch", "-J", "Job Name"]])
       end
     end
 
@@ -60,7 +60,7 @@ describe OodCore::Job::Adapters::Helper do
       let(:strict_host_checking) { true }
 
       it "defaults host checking to yes" do
-        expect(helper.ssh_wrap(submit_host, cmd, cmd_args, strict_host_checking)).to eq(["ssh", ["-p", ENV["OOD_SSH_PORT"].nil? ? 22 : ENV["OOD_SSH_PORT"], "-o", "BatchMode=yes", "-o", "UserKnownHostsFile=/dev/null", "-o", "StrictHostKeyChecking=yes", "owens.osc.edu", "sbatch", "-J", "Job Name"]])
+        expect(helper.ssh_wrap(submit_host, cmd, cmd_args, strict_host_checking)).to eq(["ssh", ["-p", ENV["OOD_SSH_PORT"].nil? ? "22" : "#{ENV['OOD_SSH_PORT']}", "-o", "BatchMode=yes", "-o", "UserKnownHostsFile=/dev/null", "-o", "StrictHostKeyChecking=yes", "owens.osc.edu", "sbatch", "-J", "Job Name"]])
       end
     end
 
@@ -69,7 +69,7 @@ describe OodCore::Job::Adapters::Helper do
       let(:strict_host_checking) { false }
 
       it "defaults host checking to no" do
-        expect(helper.ssh_wrap(submit_host, cmd, cmd_args, strict_host_checking)).to eq(["ssh", ["-p", ENV["OOD_SSH_PORT"].nil? ? 22 : ENV["OOD_SSH_PORT"], "-o", "BatchMode=yes", "-o", "UserKnownHostsFile=/dev/null", "-o", "StrictHostKeyChecking=no", "owens.osc.edu", "sbatch", "-J", "Job Name"]])
+        expect(helper.ssh_wrap(submit_host, cmd, cmd_args, strict_host_checking)).to eq(["ssh", ["-p", ENV["OOD_SSH_PORT"].nil? ? "22" : "#{ENV['OOD_SSH_PORT']}", "-o", "BatchMode=yes", "-o", "UserKnownHostsFile=/dev/null", "-o", "StrictHostKeyChecking=no", "owens.osc.edu", "sbatch", "-J", "Job Name"]])
       end
     end
   end

--- a/spec/job/adapters/helper_spec.rb
+++ b/spec/job/adapters/helper_spec.rb
@@ -51,7 +51,7 @@ describe OodCore::Job::Adapters::Helper do
       let(:submit_host) { "owens.osc.edu" }
 
       it "returns the ssh wrapped command" do 
-        expect(helper.ssh_wrap(submit_host, cmd, cmd_args)).to eq(["ssh", ["-o", "BatchMode=yes", "-o", "UserKnownHostsFile=/dev/null", "-o", "StrictHostKeyChecking=yes", "owens.osc.edu", "sbatch", "-J", "Job Name"]])
+        expect(helper.ssh_wrap(submit_host, cmd, cmd_args)).to eq(["ssh", ["-p", ENV["OOD_SSH_PORT"].nil? ? 22 : ENV["OOD_SSH_PORT"], "-o", "BatchMode=yes", "-o", "UserKnownHostsFile=/dev/null", "-o", "StrictHostKeyChecking=yes", "owens.osc.edu", "sbatch", "-J", "Job Name"]])
       end
     end
 
@@ -60,7 +60,7 @@ describe OodCore::Job::Adapters::Helper do
       let(:strict_host_checking) { true }
 
       it "defaults host checking to yes" do
-        expect(helper.ssh_wrap(submit_host, cmd, cmd_args, strict_host_checking)).to eq(["ssh", ["-o", "BatchMode=yes", "-o", "UserKnownHostsFile=/dev/null", "-o", "StrictHostKeyChecking=yes", "owens.osc.edu", "sbatch", "-J", "Job Name"]])
+        expect(helper.ssh_wrap(submit_host, cmd, cmd_args, strict_host_checking)).to eq(["ssh", ["-p", ENV["OOD_SSH_PORT"].nil? ? 22 : ENV["OOD_SSH_PORT"], "-o", "BatchMode=yes", "-o", "UserKnownHostsFile=/dev/null", "-o", "StrictHostKeyChecking=yes", "owens.osc.edu", "sbatch", "-J", "Job Name"]])
       end
     end
 
@@ -69,7 +69,7 @@ describe OodCore::Job::Adapters::Helper do
       let(:strict_host_checking) { false }
 
       it "defaults host checking to no" do
-        expect(helper.ssh_wrap(submit_host, cmd, cmd_args, strict_host_checking)).to eq(["ssh", ["-o", "BatchMode=yes", "-o", "UserKnownHostsFile=/dev/null", "-o", "StrictHostKeyChecking=no", "owens.osc.edu", "sbatch", "-J", "Job Name"]])
+        expect(helper.ssh_wrap(submit_host, cmd, cmd_args, strict_host_checking)).to eq(["ssh", ["-p", ENV["OOD_SSH_PORT"].nil? ? 22 : ENV["OOD_SSH_PORT"], "-o", "BatchMode=yes", "-o", "UserKnownHostsFile=/dev/null", "-o", "StrictHostKeyChecking=no", "owens.osc.edu", "sbatch", "-J", "Job Name"]])
       end
     end
   end

--- a/spec/job/adapters/helper_spec.rb
+++ b/spec/job/adapters/helper_spec.rb
@@ -51,7 +51,7 @@ describe OodCore::Job::Adapters::Helper do
       let(:submit_host) { "owens.osc.edu" }
 
       it "returns the ssh wrapped command" do 
-        expect(helper.ssh_wrap(submit_host, cmd, cmd_args)).to eq(["ssh", ["-p", ENV["OOD_SSH_PORT"].nil? ? "22" : "#{ENV['OOD_SSH_PORT']}", "-o", "BatchMode=yes", "-o", "UserKnownHostsFile=/dev/null", "-o", "StrictHostKeyChecking=yes", "owens.osc.edu", "sbatch", "-J", "Job Name"]])
+        expect(helper.ssh_wrap(submit_host, cmd, cmd_args)).to eq(["ssh", ["-p", "22", "-o", "BatchMode=yes", "-o", "UserKnownHostsFile=/dev/null", "-o", "StrictHostKeyChecking=yes", "owens.osc.edu", "sbatch", "-J", "Job Name"]])
       end
     end
 
@@ -60,7 +60,7 @@ describe OodCore::Job::Adapters::Helper do
       let(:strict_host_checking) { true }
 
       it "defaults host checking to yes" do
-        expect(helper.ssh_wrap(submit_host, cmd, cmd_args, strict_host_checking)).to eq(["ssh", ["-p", ENV["OOD_SSH_PORT"].nil? ? "22" : "#{ENV['OOD_SSH_PORT']}", "-o", "BatchMode=yes", "-o", "UserKnownHostsFile=/dev/null", "-o", "StrictHostKeyChecking=yes", "owens.osc.edu", "sbatch", "-J", "Job Name"]])
+        expect(helper.ssh_wrap(submit_host, cmd, cmd_args, strict_host_checking)).to eq(["ssh", ["-p", "22", "-o", "BatchMode=yes", "-o", "UserKnownHostsFile=/dev/null", "-o", "StrictHostKeyChecking=yes", "owens.osc.edu", "sbatch", "-J", "Job Name"]])
       end
     end
 
@@ -69,7 +69,7 @@ describe OodCore::Job::Adapters::Helper do
       let(:strict_host_checking) { false }
 
       it "defaults host checking to no" do
-        expect(helper.ssh_wrap(submit_host, cmd, cmd_args, strict_host_checking)).to eq(["ssh", ["-p", ENV["OOD_SSH_PORT"].nil? ? "22" : "#{ENV['OOD_SSH_PORT']}", "-o", "BatchMode=yes", "-o", "UserKnownHostsFile=/dev/null", "-o", "StrictHostKeyChecking=no", "owens.osc.edu", "sbatch", "-J", "Job Name"]])
+        expect(helper.ssh_wrap(submit_host, cmd, cmd_args, strict_host_checking)).to eq(["ssh", ["-p", "22", "-o", "BatchMode=yes", "-o", "UserKnownHostsFile=/dev/null", "-o", "StrictHostKeyChecking=no", "owens.osc.edu", "sbatch", "-J", "Job Name"]])
       end
     end
   end

--- a/spec/job/adapters/linux_host/launcher_spec.rb
+++ b/spec/job/adapters/linux_host/launcher_spec.rb
@@ -99,7 +99,7 @@ describe OodCore::Job::Adapters::LinuxHost::Launcher do
                 allow(Open3).to receive(:capture3).and_return([alt_submit_host, '', exit_success])
                 # RSpec doesn't seem to have a good way to test a non-first argument in a variadic list
                 allow(subject).to receive(:call)
-                    .with("ssh", "-t", "-p", ENV["OOD_SSH_PORT"].nil? ? "22" : "#{ENV['OOD_SSH_PORT']}", "-o", "BatchMode=yes", "#{username}@#{alt_submit_host}", any_args)
+                    .with("ssh", "-t", "-p", "22", "-o", "BatchMode=yes", "#{username}@#{alt_submit_host}", any_args)
                     .and_return('')
                 
                 subject.start_remote_session(build_script(native: {'submit_host_override' => alt_submit_host}))
@@ -264,7 +264,7 @@ describe OodCore::Job::Adapters::LinuxHost::Launcher do
             let(:ssh_cmd) { subject.send(:ssh_cmd, 'remote_host', ['/bin/bash']) }
 
             it "uses the correct SSH options" do
-                expect(ssh_cmd).to eq(['ssh', '-t', '-p', ENV['OOD_SSH_PORT'].nil? ? "22" : "#{ENV['OOD_SSH_PORT']}", '-o', 'BatchMode=yes', "#{username}@remote_host", '/bin/bash'])
+                expect(ssh_cmd).to eq(['ssh', '-t', '-p', '22', '-o', 'BatchMode=yes', "#{username}@remote_host", '/bin/bash'])
             end
         end
 
@@ -276,7 +276,7 @@ describe OodCore::Job::Adapters::LinuxHost::Launcher do
             it "uses the correct SSH options" do
                 expect(ssh_cmd).to eq([
                     'ssh', '-t',
-                    '-p', ENV['OOD_SSH_PORT'].nil? ? "22" : "#{ENV['OOD_SSH_PORT']}",
+                    '-p', '22',
                     '-o', 'BatchMode=yes',
                     '-o', 'UserKnownHostsFile=/dev/null',
                     '-o', 'StrictHostKeyChecking=no',

--- a/spec/job/adapters/linux_host/launcher_spec.rb
+++ b/spec/job/adapters/linux_host/launcher_spec.rb
@@ -99,7 +99,7 @@ describe OodCore::Job::Adapters::LinuxHost::Launcher do
                 allow(Open3).to receive(:capture3).and_return([alt_submit_host, '', exit_success])
                 # RSpec doesn't seem to have a good way to test a non-first argument in a variadic list
                 allow(subject).to receive(:call)
-                    .with("ssh", "-t", "-o", "BatchMode=yes", "#{username}@#{alt_submit_host}", any_args)
+                    .with("ssh", "-t", "-p", ENV["OOD_SSH_PORT"].nil? ? 22 : ENV["OOD_SSH_PORT"], "-o", "BatchMode=yes", "#{username}@#{alt_submit_host}", any_args)
                     .and_return('')
                 
                 subject.start_remote_session(build_script(native: {'submit_host_override' => alt_submit_host}))
@@ -264,7 +264,7 @@ describe OodCore::Job::Adapters::LinuxHost::Launcher do
             let(:ssh_cmd) { subject.send(:ssh_cmd, 'remote_host', ['/bin/bash']) }
 
             it "uses the correct SSH options" do
-                expect(ssh_cmd).to eq(['ssh', '-t', '-o', 'BatchMode=yes', "#{username}@remote_host", '/bin/bash'])
+                expect(ssh_cmd).to eq(['ssh', '-t', '-p', ENV['OOD_SSH_PORT'].nil? ? 22 : ENV['OOD_SSH_PORT'], '-o', 'BatchMode=yes', "#{username}@remote_host", '/bin/bash'])
             end
         end
 
@@ -276,6 +276,7 @@ describe OodCore::Job::Adapters::LinuxHost::Launcher do
             it "uses the correct SSH options" do
                 expect(ssh_cmd).to eq([
                     'ssh', '-t',
+                    '-p', ENV['OOD_SSH_PORT'].nil? ? 22 : ENV['OOD_SSH_PORT'],
                     '-o', 'BatchMode=yes',
                     '-o', 'UserKnownHostsFile=/dev/null',
                     '-o', 'StrictHostKeyChecking=no',

--- a/spec/job/adapters/linux_host/launcher_spec.rb
+++ b/spec/job/adapters/linux_host/launcher_spec.rb
@@ -99,7 +99,7 @@ describe OodCore::Job::Adapters::LinuxHost::Launcher do
                 allow(Open3).to receive(:capture3).and_return([alt_submit_host, '', exit_success])
                 # RSpec doesn't seem to have a good way to test a non-first argument in a variadic list
                 allow(subject).to receive(:call)
-                    .with("ssh", "-t", "-p", ENV["OOD_SSH_PORT"].nil? ? 22 : ENV["OOD_SSH_PORT"], "-o", "BatchMode=yes", "#{username}@#{alt_submit_host}", any_args)
+                    .with("ssh", "-t", "-p", ENV["OOD_SSH_PORT"].nil? ? "22" : "#{ENV['OOD_SSH_PORT']}", "-o", "BatchMode=yes", "#{username}@#{alt_submit_host}", any_args)
                     .and_return('')
                 
                 subject.start_remote_session(build_script(native: {'submit_host_override' => alt_submit_host}))
@@ -264,7 +264,7 @@ describe OodCore::Job::Adapters::LinuxHost::Launcher do
             let(:ssh_cmd) { subject.send(:ssh_cmd, 'remote_host', ['/bin/bash']) }
 
             it "uses the correct SSH options" do
-                expect(ssh_cmd).to eq(['ssh', '-t', '-p', ENV['OOD_SSH_PORT'].nil? ? 22 : ENV['OOD_SSH_PORT'], '-o', 'BatchMode=yes', "#{username}@remote_host", '/bin/bash'])
+                expect(ssh_cmd).to eq(['ssh', '-t', '-p', ENV['OOD_SSH_PORT'].nil? ? "22" : "#{ENV['OOD_SSH_PORT']}", '-o', 'BatchMode=yes', "#{username}@remote_host", '/bin/bash'])
             end
         end
 
@@ -276,7 +276,7 @@ describe OodCore::Job::Adapters::LinuxHost::Launcher do
             it "uses the correct SSH options" do
                 expect(ssh_cmd).to eq([
                     'ssh', '-t',
-                    '-p', ENV['OOD_SSH_PORT'].nil? ? 22 : ENV['OOD_SSH_PORT'],
+                    '-p', ENV['OOD_SSH_PORT'].nil? ? "22" : "#{ENV['OOD_SSH_PORT']}",
                     '-o', 'BatchMode=yes',
                     '-o', 'UserKnownHostsFile=/dev/null',
                     '-o', 'StrictHostKeyChecking=no',

--- a/spec/job/adapters/linux_host/launcher_spec.rb
+++ b/spec/job/adapters/linux_host/launcher_spec.rb
@@ -601,4 +601,25 @@ describe OodCore::Job::Adapters::LinuxHost::Launcher do
             end
         end
     end
+
+    # test ssh_cmd when OOD_SSH_PORT is set
+    context "when OOD_SSH_PORT is set" do
+        let(:username) { Etc.getlogin }
+        let(:ssh_cmd) { subject.send(:ssh_cmd, 'remote_host', ['/bin/bash']) }
+        it "uses the correct SSH options" do
+            with_modified_env({OOD_SSH_PORT: "1022"}) do 
+                expect(ssh_cmd).to eq(['ssh', '-t', '-p', '1022', '-o', 'BatchMode=yes', "#{username}@remote_host", '/bin/bash'])
+            end
+        end
+    end
+
+    # test ssh_cmd when OOD_SSH_PORT is not set
+    context "when OOD_SSH_PORT is not set" do
+        let(:username) { Etc.getlogin }
+        let(:ssh_cmd) { subject.send(:ssh_cmd, 'remote_host', ['/bin/bash']) }
+        it "uses the correct SSH options" do
+            expect(ssh_cmd).to eq(['ssh', '-t', '-p', '22', '-o', 'BatchMode=yes', "#{username}@remote_host", '/bin/bash'])
+        end
+    end
+
 end

--- a/spec/job/adapters/lsf/batch_spec.rb
+++ b/spec/job/adapters/lsf/batch_spec.rb
@@ -277,7 +277,7 @@ JOBID      USER    STAT  QUEUE      FROM_HOST   EXEC_HOST   JOB_NAME   SUBMIT_TI
         allow(Open3).to receive(:capture3).and_return(["job.123", "", double("success?" => true)])
 
         batch.submit_string(script.content)
-        expect(Open3).to have_received(:capture3).with(anything, 'ssh', '-p', ENV['OOD_SSH_PORT'].nil? ? 22 : ENV['OOD_SSH_PORT'], '-o', 'BatchMode=yes', '-o', 'UserKnownHostsFile=/dev/null', '-o', 'StrictHostKeyChecking=yes', 'owens.osc.edu', 'bsub', any_args)
+        expect(Open3).to have_received(:capture3).with(anything, 'ssh', '-p', ENV['OOD_SSH_PORT'].nil? ? "22" : "#{ENV['OOD_SSH_PORT']}", '-o', 'BatchMode=yes', '-o', 'UserKnownHostsFile=/dev/null', '-o', 'StrictHostKeyChecking=yes', 'owens.osc.edu', 'bsub', any_args)
       end
     end
 
@@ -287,7 +287,7 @@ JOBID      USER    STAT  QUEUE      FROM_HOST   EXEC_HOST   JOB_NAME   SUBMIT_TI
         allow(Open3).to receive(:capture3).and_return(["job.123", "", double("success?" => true)])
 
         batch.submit_string(script.content)
-        expect(Open3).to have_received(:capture3).with(anything, 'ssh', '-p', ENV['OOD_SSH_PORT'].nil? ? 22 : ENV['OOD_SSH_PORT'], '-o', 'BatchMode=yes', '-o', 'UserKnownHostsFile=/dev/null', '-o', 'StrictHostKeyChecking=no', 'owens.osc.edu', 'bsub', any_args)
+        expect(Open3).to have_received(:capture3).with(anything, 'ssh', '-p', ENV['OOD_SSH_PORT'].nil? ? "22" : "#{ENV['OOD_SSH_PORT']}", '-o', 'BatchMode=yes', '-o', 'UserKnownHostsFile=/dev/null', '-o', 'StrictHostKeyChecking=no', 'owens.osc.edu', 'bsub', any_args)
       end
     end
     

--- a/spec/job/adapters/lsf/batch_spec.rb
+++ b/spec/job/adapters/lsf/batch_spec.rb
@@ -277,7 +277,7 @@ JOBID      USER    STAT  QUEUE      FROM_HOST   EXEC_HOST   JOB_NAME   SUBMIT_TI
         allow(Open3).to receive(:capture3).and_return(["job.123", "", double("success?" => true)])
 
         batch.submit_string(script.content)
-        expect(Open3).to have_received(:capture3).with(anything, 'ssh', '-p', ENV['OOD_SSH_PORT'].nil? ? "22" : "#{ENV['OOD_SSH_PORT']}", '-o', 'BatchMode=yes', '-o', 'UserKnownHostsFile=/dev/null', '-o', 'StrictHostKeyChecking=yes', 'owens.osc.edu', 'bsub', any_args)
+        expect(Open3).to have_received(:capture3).with(anything, 'ssh', '-p', '22', '-o', 'BatchMode=yes', '-o', 'UserKnownHostsFile=/dev/null', '-o', 'StrictHostKeyChecking=yes', 'owens.osc.edu', 'bsub', any_args)
       end
     end
 
@@ -287,7 +287,7 @@ JOBID      USER    STAT  QUEUE      FROM_HOST   EXEC_HOST   JOB_NAME   SUBMIT_TI
         allow(Open3).to receive(:capture3).and_return(["job.123", "", double("success?" => true)])
 
         batch.submit_string(script.content)
-        expect(Open3).to have_received(:capture3).with(anything, 'ssh', '-p', ENV['OOD_SSH_PORT'].nil? ? "22" : "#{ENV['OOD_SSH_PORT']}", '-o', 'BatchMode=yes', '-o', 'UserKnownHostsFile=/dev/null', '-o', 'StrictHostKeyChecking=no', 'owens.osc.edu', 'bsub', any_args)
+        expect(Open3).to have_received(:capture3).with(anything, 'ssh', '-p', '22', '-o', 'BatchMode=yes', '-o', 'UserKnownHostsFile=/dev/null', '-o', 'StrictHostKeyChecking=no', 'owens.osc.edu', 'bsub', any_args)
       end
     end
     

--- a/spec/job/adapters/lsf/batch_spec.rb
+++ b/spec/job/adapters/lsf/batch_spec.rb
@@ -277,7 +277,7 @@ JOBID      USER    STAT  QUEUE      FROM_HOST   EXEC_HOST   JOB_NAME   SUBMIT_TI
         allow(Open3).to receive(:capture3).and_return(["job.123", "", double("success?" => true)])
 
         batch.submit_string(script.content)
-        expect(Open3).to have_received(:capture3).with(anything, 'ssh', '-o', 'BatchMode=yes', '-o', 'UserKnownHostsFile=/dev/null', '-o', 'StrictHostKeyChecking=yes', 'owens.osc.edu', 'bsub', any_args)
+        expect(Open3).to have_received(:capture3).with(anything, 'ssh', '-p', ENV['OOD_SSH_PORT'].nil? ? 22 : ENV['OOD_SSH_PORT'], '-o', 'BatchMode=yes', '-o', 'UserKnownHostsFile=/dev/null', '-o', 'StrictHostKeyChecking=yes', 'owens.osc.edu', 'bsub', any_args)
       end
     end
 
@@ -287,7 +287,7 @@ JOBID      USER    STAT  QUEUE      FROM_HOST   EXEC_HOST   JOB_NAME   SUBMIT_TI
         allow(Open3).to receive(:capture3).and_return(["job.123", "", double("success?" => true)])
 
         batch.submit_string(script.content)
-        expect(Open3).to have_received(:capture3).with(anything, 'ssh', '-o', 'BatchMode=yes', '-o', 'UserKnownHostsFile=/dev/null', '-o', 'StrictHostKeyChecking=no', 'owens.osc.edu', 'bsub', any_args)
+        expect(Open3).to have_received(:capture3).with(anything, 'ssh', '-p', ENV['OOD_SSH_PORT'].nil? ? 22 : ENV['OOD_SSH_PORT'], '-o', 'BatchMode=yes', '-o', 'UserKnownHostsFile=/dev/null', '-o', 'StrictHostKeyChecking=no', 'owens.osc.edu', 'bsub', any_args)
       end
     end
     

--- a/spec/job/adapters/pbspro_spec.rb
+++ b/spec/job/adapters/pbspro_spec.rb
@@ -867,7 +867,7 @@ describe OodCore::Job::Adapters::PBSPro do
         allow(Open3).to receive(:capture3).and_return(["job.123", "", double("success?" => true)])
 
         OodCore::Job::Adapters::PBSPro.new(pbspro: batch, qstat_factor: nil).submit script
-        expect(Open3).to have_received(:capture3).with(anything,'ssh', '-p', ENV['OOD_SSH_PORT'].nil? ? 22 : ENV['OOD_SSH_PORT'], '-o', 'BatchMode=yes', '-o', 'UserKnownHostsFile=/dev/null', '-o', 'StrictHostKeyChecking=yes', 'owens.osc.edu', 'qsub', '-j', 'oe', any_args)
+        expect(Open3).to have_received(:capture3).with(anything,'ssh', '-p', ENV['OOD_SSH_PORT'].nil? ? "22" : "#{ENV['OOD_SSH_PORT']}", '-o', 'BatchMode=yes', '-o', 'UserKnownHostsFile=/dev/null', '-o', 'StrictHostKeyChecking=yes', 'owens.osc.edu', 'qsub', '-j', 'oe', any_args)
       end
     end
 
@@ -877,7 +877,7 @@ describe OodCore::Job::Adapters::PBSPro do
         allow(Open3).to receive(:capture3).and_return(["job.123", "", double("success?" => true)])
 
         OodCore::Job::Adapters::PBSPro.new(pbspro: batch, qstat_factor: nil).submit script
-        expect(Open3).to have_received(:capture3).with(anything,'ssh', '-p', ENV['OOD_SSH_PORT'].nil? ? 22 : ENV['OOD_SSH_PORT'], '-o', 'BatchMode=yes', '-o', 'UserKnownHostsFile=/dev/null', '-o', 'StrictHostKeyChecking=no', 'owens.osc.edu', 'qsub', '-j', 'oe', any_args)
+        expect(Open3).to have_received(:capture3).with(anything,'ssh', '-p', ENV['OOD_SSH_PORT'].nil? ? "22" : "#{ENV['OOD_SSH_PORT']}", '-o', 'BatchMode=yes', '-o', 'UserKnownHostsFile=/dev/null', '-o', 'StrictHostKeyChecking=no', 'owens.osc.edu', 'qsub', '-j', 'oe', any_args)
       end
     end
   end

--- a/spec/job/adapters/pbspro_spec.rb
+++ b/spec/job/adapters/pbspro_spec.rb
@@ -867,7 +867,7 @@ describe OodCore::Job::Adapters::PBSPro do
         allow(Open3).to receive(:capture3).and_return(["job.123", "", double("success?" => true)])
 
         OodCore::Job::Adapters::PBSPro.new(pbspro: batch, qstat_factor: nil).submit script
-        expect(Open3).to have_received(:capture3).with(anything,'ssh', '-p', ENV['OOD_SSH_PORT'].nil? ? "22" : "#{ENV['OOD_SSH_PORT']}", '-o', 'BatchMode=yes', '-o', 'UserKnownHostsFile=/dev/null', '-o', 'StrictHostKeyChecking=yes', 'owens.osc.edu', 'qsub', '-j', 'oe', any_args)
+        expect(Open3).to have_received(:capture3).with(anything,'ssh', '-p', '22', '-o', 'BatchMode=yes', '-o', 'UserKnownHostsFile=/dev/null', '-o', 'StrictHostKeyChecking=yes', 'owens.osc.edu', 'qsub', '-j', 'oe', any_args)
       end
     end
 
@@ -877,7 +877,7 @@ describe OodCore::Job::Adapters::PBSPro do
         allow(Open3).to receive(:capture3).and_return(["job.123", "", double("success?" => true)])
 
         OodCore::Job::Adapters::PBSPro.new(pbspro: batch, qstat_factor: nil).submit script
-        expect(Open3).to have_received(:capture3).with(anything,'ssh', '-p', ENV['OOD_SSH_PORT'].nil? ? "22" : "#{ENV['OOD_SSH_PORT']}", '-o', 'BatchMode=yes', '-o', 'UserKnownHostsFile=/dev/null', '-o', 'StrictHostKeyChecking=no', 'owens.osc.edu', 'qsub', '-j', 'oe', any_args)
+        expect(Open3).to have_received(:capture3).with(anything,'ssh', '-p', '22', '-o', 'BatchMode=yes', '-o', 'UserKnownHostsFile=/dev/null', '-o', 'StrictHostKeyChecking=no', 'owens.osc.edu', 'qsub', '-j', 'oe', any_args)
       end
     end
   end

--- a/spec/job/adapters/pbspro_spec.rb
+++ b/spec/job/adapters/pbspro_spec.rb
@@ -867,7 +867,7 @@ describe OodCore::Job::Adapters::PBSPro do
         allow(Open3).to receive(:capture3).and_return(["job.123", "", double("success?" => true)])
 
         OodCore::Job::Adapters::PBSPro.new(pbspro: batch, qstat_factor: nil).submit script
-        expect(Open3).to have_received(:capture3).with(anything,'ssh', '-o', 'BatchMode=yes', '-o', 'UserKnownHostsFile=/dev/null', '-o', 'StrictHostKeyChecking=yes', 'owens.osc.edu', 'qsub', '-j', 'oe', any_args)
+        expect(Open3).to have_received(:capture3).with(anything,'ssh', '-p', ENV['OOD_SSH_PORT'].nil? ? 22 : ENV['OOD_SSH_PORT'], '-o', 'BatchMode=yes', '-o', 'UserKnownHostsFile=/dev/null', '-o', 'StrictHostKeyChecking=yes', 'owens.osc.edu', 'qsub', '-j', 'oe', any_args)
       end
     end
 
@@ -877,7 +877,7 @@ describe OodCore::Job::Adapters::PBSPro do
         allow(Open3).to receive(:capture3).and_return(["job.123", "", double("success?" => true)])
 
         OodCore::Job::Adapters::PBSPro.new(pbspro: batch, qstat_factor: nil).submit script
-        expect(Open3).to have_received(:capture3).with(anything,'ssh', '-o', 'BatchMode=yes', '-o', 'UserKnownHostsFile=/dev/null', '-o', 'StrictHostKeyChecking=no', 'owens.osc.edu', 'qsub', '-j', 'oe', any_args)
+        expect(Open3).to have_received(:capture3).with(anything,'ssh', '-p', ENV['OOD_SSH_PORT'].nil? ? 22 : ENV['OOD_SSH_PORT'], '-o', 'BatchMode=yes', '-o', 'UserKnownHostsFile=/dev/null', '-o', 'StrictHostKeyChecking=no', 'owens.osc.edu', 'qsub', '-j', 'oe', any_args)
       end
     end
   end

--- a/spec/job/adapters/sge/batch_spec.rb
+++ b/spec/job/adapters/sge/batch_spec.rb
@@ -360,7 +360,7 @@ describe OodCore::Job::Adapters::Sge::Batch do
         allow(Open3).to receive(:capture3).and_return(["Your job 123", "", double("success?" => true)])
 
         OodCore::Job::Adapters::Sge.new(batch: batch).submit script
-        expect(Open3).to have_received(:capture3).with(anything, 'ssh', '-p', ENV['OOD_SSH_PORT'].nil? ? "22" : "#{ENV['OOD_SSH_PORT']}", '-o', 'BatchMode=yes', '-o', 'UserKnownHostsFile=/dev/null', '-o', 'StrictHostKeyChecking=yes', 'owens.osc.edu', 'qsub', '-cwd', any_args)
+        expect(Open3).to have_received(:capture3).with(anything, 'ssh', '-p', '22', '-o', 'BatchMode=yes', '-o', 'UserKnownHostsFile=/dev/null', '-o', 'StrictHostKeyChecking=yes', 'owens.osc.edu', 'qsub', '-cwd', any_args)
       end
     end
 
@@ -370,7 +370,7 @@ describe OodCore::Job::Adapters::Sge::Batch do
         allow(Open3).to receive(:capture3).and_return(["Your job 123", "", double("success?" => true)])
 
         OodCore::Job::Adapters::Sge.new(batch: batch).submit script
-        expect(Open3).to have_received(:capture3).with(anything, 'ssh', '-p', ENV['OOD_SSH_PORT'].nil? ? "22" : "#{ENV['OOD_SSH_PORT']}", '-o', 'BatchMode=yes', '-o', 'UserKnownHostsFile=/dev/null', '-o', 'StrictHostKeyChecking=no', 'owens.osc.edu', 'qsub', '-cwd', any_args)
+        expect(Open3).to have_received(:capture3).with(anything, 'ssh', '-p', '22', '-o', 'BatchMode=yes', '-o', 'UserKnownHostsFile=/dev/null', '-o', 'StrictHostKeyChecking=no', 'owens.osc.edu', 'qsub', '-cwd', any_args)
       end
     end
   end

--- a/spec/job/adapters/sge/batch_spec.rb
+++ b/spec/job/adapters/sge/batch_spec.rb
@@ -360,7 +360,7 @@ describe OodCore::Job::Adapters::Sge::Batch do
         allow(Open3).to receive(:capture3).and_return(["Your job 123", "", double("success?" => true)])
 
         OodCore::Job::Adapters::Sge.new(batch: batch).submit script
-        expect(Open3).to have_received(:capture3).with(anything, 'ssh', '-o', 'BatchMode=yes', '-o', 'UserKnownHostsFile=/dev/null', '-o', 'StrictHostKeyChecking=yes', 'owens.osc.edu', 'qsub', '-cwd', any_args)
+        expect(Open3).to have_received(:capture3).with(anything, 'ssh', '-p', ENV['OOD_SSH_PORT'].nil? ? 22 : ENV['OOD_SSH_PORT'], '-o', 'BatchMode=yes', '-o', 'UserKnownHostsFile=/dev/null', '-o', 'StrictHostKeyChecking=yes', 'owens.osc.edu', 'qsub', '-cwd', any_args)
       end
     end
 
@@ -370,7 +370,7 @@ describe OodCore::Job::Adapters::Sge::Batch do
         allow(Open3).to receive(:capture3).and_return(["Your job 123", "", double("success?" => true)])
 
         OodCore::Job::Adapters::Sge.new(batch: batch).submit script
-        expect(Open3).to have_received(:capture3).with(anything, 'ssh', '-o', 'BatchMode=yes', '-o', 'UserKnownHostsFile=/dev/null', '-o', 'StrictHostKeyChecking=no', 'owens.osc.edu', 'qsub', '-cwd', any_args)
+        expect(Open3).to have_received(:capture3).with(anything, 'ssh', '-p', ENV['OOD_SSH_PORT'].nil? ? 22 : ENV['OOD_SSH_PORT'], '-o', 'BatchMode=yes', '-o', 'UserKnownHostsFile=/dev/null', '-o', 'StrictHostKeyChecking=no', 'owens.osc.edu', 'qsub', '-cwd', any_args)
       end
     end
   end

--- a/spec/job/adapters/sge/batch_spec.rb
+++ b/spec/job/adapters/sge/batch_spec.rb
@@ -360,7 +360,7 @@ describe OodCore::Job::Adapters::Sge::Batch do
         allow(Open3).to receive(:capture3).and_return(["Your job 123", "", double("success?" => true)])
 
         OodCore::Job::Adapters::Sge.new(batch: batch).submit script
-        expect(Open3).to have_received(:capture3).with(anything, 'ssh', '-p', ENV['OOD_SSH_PORT'].nil? ? 22 : ENV['OOD_SSH_PORT'], '-o', 'BatchMode=yes', '-o', 'UserKnownHostsFile=/dev/null', '-o', 'StrictHostKeyChecking=yes', 'owens.osc.edu', 'qsub', '-cwd', any_args)
+        expect(Open3).to have_received(:capture3).with(anything, 'ssh', '-p', ENV['OOD_SSH_PORT'].nil? ? "22" : "#{ENV['OOD_SSH_PORT']}", '-o', 'BatchMode=yes', '-o', 'UserKnownHostsFile=/dev/null', '-o', 'StrictHostKeyChecking=yes', 'owens.osc.edu', 'qsub', '-cwd', any_args)
       end
     end
 
@@ -370,7 +370,7 @@ describe OodCore::Job::Adapters::Sge::Batch do
         allow(Open3).to receive(:capture3).and_return(["Your job 123", "", double("success?" => true)])
 
         OodCore::Job::Adapters::Sge.new(batch: batch).submit script
-        expect(Open3).to have_received(:capture3).with(anything, 'ssh', '-p', ENV['OOD_SSH_PORT'].nil? ? 22 : ENV['OOD_SSH_PORT'], '-o', 'BatchMode=yes', '-o', 'UserKnownHostsFile=/dev/null', '-o', 'StrictHostKeyChecking=no', 'owens.osc.edu', 'qsub', '-cwd', any_args)
+        expect(Open3).to have_received(:capture3).with(anything, 'ssh', '-p', ENV['OOD_SSH_PORT'].nil? ? "22" : "#{ENV['OOD_SSH_PORT']}", '-o', 'BatchMode=yes', '-o', 'UserKnownHostsFile=/dev/null', '-o', 'StrictHostKeyChecking=no', 'owens.osc.edu', 'qsub', '-cwd', any_args)
       end
     end
   end

--- a/spec/job/adapters/slurm_spec.rb
+++ b/spec/job/adapters/slurm_spec.rb
@@ -1177,7 +1177,7 @@ describe OodCore::Job::Adapters::Slurm do
         allow(Open3).to receive(:capture3).and_return(["job.123", "", double("success?" => true)])
 
         OodCore::Job::Adapters::Slurm.new(slurm: batch).submit script
-        expect(Open3).to have_received(:capture3).with(anything, 'ssh', '-p', ENV['OOD_SSH_PORT'].nil? ? 22 : ENV['OOD_SSH_PORT'], '-o', 'BatchMode=yes', '-o', 'UserKnownHostsFile=/dev/null', '-o', 'StrictHostKeyChecking=yes', 'owens.osc.edu', 'sbatch', '--export', 'NONE', '--parsable', '-M', 'owens.osc.edu', any_args)
+        expect(Open3).to have_received(:capture3).with(anything, 'ssh', '-p', ENV['OOD_SSH_PORT'].nil? ? "22" : "#{ENV['OOD_SSH_PORT']}", '-o', 'BatchMode=yes', '-o', 'UserKnownHostsFile=/dev/null', '-o', 'StrictHostKeyChecking=yes', 'owens.osc.edu', 'sbatch', '--export', 'NONE', '--parsable', '-M', 'owens.osc.edu', any_args)
       end
     end
 
@@ -1187,7 +1187,7 @@ describe OodCore::Job::Adapters::Slurm do
         allow(Open3).to receive(:capture3).and_return(["job.123", "", double("success?" => true)])
 
         OodCore::Job::Adapters::Slurm.new(slurm: batch).submit script
-        expect(Open3).to have_received(:capture3).with(anything, 'ssh', '-p', ENV['OOD_SSH_PORT'].nil? ? 22 : ENV['OOD_SSH_PORT'], '-o', 'BatchMode=yes', '-o', 'UserKnownHostsFile=/dev/null', '-o', 'StrictHostKeyChecking=no', 'owens.osc.edu', 'sbatch', '--export', 'NONE', '--parsable', '-M', 'owens.osc.edu', any_args)
+        expect(Open3).to have_received(:capture3).with(anything, 'ssh', '-p', ENV['OOD_SSH_PORT'].nil? ? "22" : "#{ENV['OOD_SSH_PORT']}", '-o', 'BatchMode=yes', '-o', 'UserKnownHostsFile=/dev/null', '-o', 'StrictHostKeyChecking=no', 'owens.osc.edu', 'sbatch', '--export', 'NONE', '--parsable', '-M', 'owens.osc.edu', any_args)
       end
     end
   end

--- a/spec/job/adapters/slurm_spec.rb
+++ b/spec/job/adapters/slurm_spec.rb
@@ -1177,7 +1177,7 @@ describe OodCore::Job::Adapters::Slurm do
         allow(Open3).to receive(:capture3).and_return(["job.123", "", double("success?" => true)])
 
         OodCore::Job::Adapters::Slurm.new(slurm: batch).submit script
-        expect(Open3).to have_received(:capture3).with(anything, 'ssh', '-p', ENV['OOD_SSH_PORT'].nil? ? "22" : "#{ENV['OOD_SSH_PORT']}", '-o', 'BatchMode=yes', '-o', 'UserKnownHostsFile=/dev/null', '-o', 'StrictHostKeyChecking=yes', 'owens.osc.edu', 'sbatch', '--export', 'NONE', '--parsable', '-M', 'owens.osc.edu', any_args)
+        expect(Open3).to have_received(:capture3).with(anything, 'ssh', '-p', '22', '-o', 'BatchMode=yes', '-o', 'UserKnownHostsFile=/dev/null', '-o', 'StrictHostKeyChecking=yes', 'owens.osc.edu', 'sbatch', '--export', 'NONE', '--parsable', '-M', 'owens.osc.edu', any_args)
       end
     end
 
@@ -1187,7 +1187,7 @@ describe OodCore::Job::Adapters::Slurm do
         allow(Open3).to receive(:capture3).and_return(["job.123", "", double("success?" => true)])
 
         OodCore::Job::Adapters::Slurm.new(slurm: batch).submit script
-        expect(Open3).to have_received(:capture3).with(anything, 'ssh', '-p', ENV['OOD_SSH_PORT'].nil? ? "22" : "#{ENV['OOD_SSH_PORT']}", '-o', 'BatchMode=yes', '-o', 'UserKnownHostsFile=/dev/null', '-o', 'StrictHostKeyChecking=no', 'owens.osc.edu', 'sbatch', '--export', 'NONE', '--parsable', '-M', 'owens.osc.edu', any_args)
+        expect(Open3).to have_received(:capture3).with(anything, 'ssh', '-p', '22', '-o', 'BatchMode=yes', '-o', 'UserKnownHostsFile=/dev/null', '-o', 'StrictHostKeyChecking=no', 'owens.osc.edu', 'sbatch', '--export', 'NONE', '--parsable', '-M', 'owens.osc.edu', any_args)
       end
     end
   end

--- a/spec/job/adapters/slurm_spec.rb
+++ b/spec/job/adapters/slurm_spec.rb
@@ -1177,7 +1177,7 @@ describe OodCore::Job::Adapters::Slurm do
         allow(Open3).to receive(:capture3).and_return(["job.123", "", double("success?" => true)])
 
         OodCore::Job::Adapters::Slurm.new(slurm: batch).submit script
-        expect(Open3).to have_received(:capture3).with(anything, 'ssh', '-o', 'BatchMode=yes', '-o', 'UserKnownHostsFile=/dev/null', '-o', 'StrictHostKeyChecking=yes', 'owens.osc.edu', 'sbatch', '--export', 'NONE', '--parsable', '-M', 'owens.osc.edu', any_args)
+        expect(Open3).to have_received(:capture3).with(anything, 'ssh', '-p', ENV['OOD_SSH_PORT'].nil? ? 22 : ENV['OOD_SSH_PORT'], '-o', 'BatchMode=yes', '-o', 'UserKnownHostsFile=/dev/null', '-o', 'StrictHostKeyChecking=yes', 'owens.osc.edu', 'sbatch', '--export', 'NONE', '--parsable', '-M', 'owens.osc.edu', any_args)
       end
     end
 
@@ -1187,7 +1187,7 @@ describe OodCore::Job::Adapters::Slurm do
         allow(Open3).to receive(:capture3).and_return(["job.123", "", double("success?" => true)])
 
         OodCore::Job::Adapters::Slurm.new(slurm: batch).submit script
-        expect(Open3).to have_received(:capture3).with(anything, 'ssh', '-o', 'BatchMode=yes', '-o', 'UserKnownHostsFile=/dev/null', '-o', 'StrictHostKeyChecking=no', 'owens.osc.edu', 'sbatch', '--export', 'NONE', '--parsable', '-M', 'owens.osc.edu', any_args)
+        expect(Open3).to have_received(:capture3).with(anything, 'ssh', '-p', ENV['OOD_SSH_PORT'].nil? ? 22 : ENV['OOD_SSH_PORT'], '-o', 'BatchMode=yes', '-o', 'UserKnownHostsFile=/dev/null', '-o', 'StrictHostKeyChecking=no', 'owens.osc.edu', 'sbatch', '--export', 'NONE', '--parsable', '-M', 'owens.osc.edu', any_args)
       end
     end
   end

--- a/spec/job/adapters/torque/batch_spec.rb
+++ b/spec/job/adapters/torque/batch_spec.rb
@@ -193,7 +193,7 @@ describe OodCore::Job::Adapters::Torque::Batch do
         allow(Open3).to receive(:capture3).and_return(["job.123", "", double("success?" => true)])
 
         batch.submit script.content
-        expect(Open3).to have_received(:capture3).with(anything,'ssh', '-p', ENV['OOD_SSH_PORT'].nil? ? 22 : ENV['OOD_SSH_PORT'], '-o', 'BatchMode=yes', '-o', 'UserKnownHostsFile=/dev/null', '-o', 'StrictHostKeyChecking=yes', 'owens.osc.edu', /['export PBS_DEFAULT','export LD_LIBRARY_PATH','qsub']/, any_args)
+        expect(Open3).to have_received(:capture3).with(anything,'ssh', '-p', ENV['OOD_SSH_PORT'].nil? ? "22" : "#{ENV['OOD_SSH_PORT']}", '-o', 'BatchMode=yes', '-o', 'UserKnownHostsFile=/dev/null', '-o', 'StrictHostKeyChecking=yes', 'owens.osc.edu', /['export PBS_DEFAULT','export LD_LIBRARY_PATH','qsub']/, any_args)
       end
     end
 
@@ -203,7 +203,7 @@ describe OodCore::Job::Adapters::Torque::Batch do
         allow(Open3).to receive(:capture3).and_return(["job.123", "", double("success?" => true)])
 
         batch.submit script.content
-        expect(Open3).to have_received(:capture3).with(anything,'ssh', '-p', ENV['OOD_SSH_PORT'].nil? ? 22 : ENV['OOD_SSH_PORT'], '-o', 'BatchMode=yes', '-o', 'UserKnownHostsFile=/dev/null', '-o', 'StrictHostKeyChecking=no', 'owens.osc.edu', /['export PBS_DEFAULT','export LD_LIBRARY_PATH','qsub']/, any_args)
+        expect(Open3).to have_received(:capture3).with(anything,'ssh', '-p', ENV['OOD_SSH_PORT'].nil? ? "22" : "#{ENV['OOD_SSH_PORT']}", '-o', 'BatchMode=yes', '-o', 'UserKnownHostsFile=/dev/null', '-o', 'StrictHostKeyChecking=no', 'owens.osc.edu', /['export PBS_DEFAULT','export LD_LIBRARY_PATH','qsub']/, any_args)
       end
     end
   end

--- a/spec/job/adapters/torque/batch_spec.rb
+++ b/spec/job/adapters/torque/batch_spec.rb
@@ -193,7 +193,7 @@ describe OodCore::Job::Adapters::Torque::Batch do
         allow(Open3).to receive(:capture3).and_return(["job.123", "", double("success?" => true)])
 
         batch.submit script.content
-        expect(Open3).to have_received(:capture3).with(anything,'ssh', '-o', 'BatchMode=yes', '-o', 'UserKnownHostsFile=/dev/null', '-o', 'StrictHostKeyChecking=yes', 'owens.osc.edu', /['export PBS_DEFAULT','export LD_LIBRARY_PATH','qsub']/, any_args)
+        expect(Open3).to have_received(:capture3).with(anything,'ssh', '-p', ENV['OOD_SSH_PORT'].nil? ? 22 : ENV['OOD_SSH_PORT'], '-o', 'BatchMode=yes', '-o', 'UserKnownHostsFile=/dev/null', '-o', 'StrictHostKeyChecking=yes', 'owens.osc.edu', /['export PBS_DEFAULT','export LD_LIBRARY_PATH','qsub']/, any_args)
       end
     end
 
@@ -203,7 +203,7 @@ describe OodCore::Job::Adapters::Torque::Batch do
         allow(Open3).to receive(:capture3).and_return(["job.123", "", double("success?" => true)])
 
         batch.submit script.content
-        expect(Open3).to have_received(:capture3).with(anything,'ssh', '-o', 'BatchMode=yes', '-o', 'UserKnownHostsFile=/dev/null', '-o', 'StrictHostKeyChecking=no', 'owens.osc.edu', /['export PBS_DEFAULT','export LD_LIBRARY_PATH','qsub']/, any_args)
+        expect(Open3).to have_received(:capture3).with(anything,'ssh', '-p', ENV['OOD_SSH_PORT'].nil? ? 22 : ENV['OOD_SSH_PORT'], '-o', 'BatchMode=yes', '-o', 'UserKnownHostsFile=/dev/null', '-o', 'StrictHostKeyChecking=no', 'owens.osc.edu', /['export PBS_DEFAULT','export LD_LIBRARY_PATH','qsub']/, any_args)
       end
     end
   end

--- a/spec/job/adapters/torque/batch_spec.rb
+++ b/spec/job/adapters/torque/batch_spec.rb
@@ -193,7 +193,7 @@ describe OodCore::Job::Adapters::Torque::Batch do
         allow(Open3).to receive(:capture3).and_return(["job.123", "", double("success?" => true)])
 
         batch.submit script.content
-        expect(Open3).to have_received(:capture3).with(anything,'ssh', '-p', ENV['OOD_SSH_PORT'].nil? ? "22" : "#{ENV['OOD_SSH_PORT']}", '-o', 'BatchMode=yes', '-o', 'UserKnownHostsFile=/dev/null', '-o', 'StrictHostKeyChecking=yes', 'owens.osc.edu', /['export PBS_DEFAULT','export LD_LIBRARY_PATH','qsub']/, any_args)
+        expect(Open3).to have_received(:capture3).with(anything,'ssh', '-p', '22', '-o', 'BatchMode=yes', '-o', 'UserKnownHostsFile=/dev/null', '-o', 'StrictHostKeyChecking=yes', 'owens.osc.edu', /['export PBS_DEFAULT','export LD_LIBRARY_PATH','qsub']/, any_args)
       end
     end
 
@@ -203,7 +203,7 @@ describe OodCore::Job::Adapters::Torque::Batch do
         allow(Open3).to receive(:capture3).and_return(["job.123", "", double("success?" => true)])
 
         batch.submit script.content
-        expect(Open3).to have_received(:capture3).with(anything,'ssh', '-p', ENV['OOD_SSH_PORT'].nil? ? "22" : "#{ENV['OOD_SSH_PORT']}", '-o', 'BatchMode=yes', '-o', 'UserKnownHostsFile=/dev/null', '-o', 'StrictHostKeyChecking=no', 'owens.osc.edu', /['export PBS_DEFAULT','export LD_LIBRARY_PATH','qsub']/, any_args)
+        expect(Open3).to have_received(:capture3).with(anything,'ssh', '-p', '22', '-o', 'BatchMode=yes', '-o', 'UserKnownHostsFile=/dev/null', '-o', 'StrictHostKeyChecking=no', 'owens.osc.edu', /['export PBS_DEFAULT','export LD_LIBRARY_PATH','qsub']/, any_args)
       end
     end
   end


### PR DESCRIPTION
Added Functionality to support Non-Standard SSH Port in the Adapters.

The environment variable for ssh port is:  ENV['OOD_SSH_PORT']

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1135148780858012/1203988635385114) by [Unito](https://www.unito.io)
