### PR TITLE
use the full path for k8sjobinfo and throw any errors up the stack

### DIFF
--- a/lib/ood_core/job/adapters/kubernetes/batch.rb
+++ b/lib/ood_core/job/adapters/kubernetes/batch.rb
@@ -306,10 +306,7 @@ class OodCore::Job::Adapters::Kubernetes::Batch
 
   def pod_info_from_json(pod)
     hash = helper.pod_info_from_json(pod)
-    K8sJobInfo.new(hash)
-  rescue Helper::K8sDataError
-    # FIXME: silently eating error, could probably use a logger
-    nil
+    OodCore::Job::Adapters::Kubernetes::K8sJobInfo.new(hash)
   end
 
   def configure_auth(auth)


### PR DESCRIPTION
Fixes #803 by using the full path for the K8sJobInfo object and throws any errors up the stack because OOD can catch them.

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1135148780858012/1204309611557787) by [Unito](https://www.unito.io)
