### PR TITLE
Add OUT_OF_MEMORY state for Slurm

### DIFF
--- a/lib/ood_core/job/adapters/slurm.rb
+++ b/lib/ood_core/job/adapters/slurm.rb
@@ -436,7 +436,8 @@ module OodCore
           'SE' => :completed,  # SPECIAL_EXIT
           'ST' => :running,    # STOPPED
           'S'  => :suspended,  # SUSPENDED
-          'TO' => :completed   # TIMEOUT
+          'TO' => :completed,   # TIMEOUT
+          'OOM' => :completed   # OUT_OF_MEMORY
         }
 
         # @api private


### PR DESCRIPTION
We are currently setting up OOD in a cluster where Slurm seems to use the state OOM/OUT_OF_MEMORY for jobs that were terminated due to exceeded the allocated memory. This PR makes OOD handle that state too.

Example:
![image](https://github.com/OSC/ood_core/assets/61623634/3b451b50-9f2f-431e-8c91-4aa8bb366bed)
