### PR TITLE
handle find_port error codes

### DIFF
--- a/lib/ood_core/batch_connect/templates/vnc.rb
+++ b/lib/ood_core/batch_connect/templates/vnc.rb
@@ -137,6 +137,7 @@ module OodCore
               # Launch websockify websocket server
               echo "Starting websocket server..."
               websocket=$(find_port)
+              [ $? -eq 0 ] || clean_up 1 # give up if port not found
               #{websockify_cmd} -D ${websocket} localhost:${port}
 
               # Set up background process that scans the log file for successful

--- a/lib/ood_core/batch_connect/templates/vnc_container.rb
+++ b/lib/ood_core/batch_connect/templates/vnc_container.rb
@@ -173,6 +173,7 @@ module OodCore
               module load #{container_module}
               echo "Starting websocket server..."
               websocket=$(find_port)
+              [ $? -eq 0 ] || clean_up 1 # give up if port not found
               #{container_command} exec instance://#{@instance_name} #{websockify_cmd} -D ${websocket} localhost:${port}
 
               # Set up background process that scans the log file for successful


### PR DESCRIPTION
if `find_port` fails to find a free port, we give up and cleanup. Updating vnc/vnc_container templates accordingly.