### PR TITLE
Changes default return value for cluster.batch_connect_ssh_allow?

### DIFF
--- a/lib/ood_core/cluster.rb
+++ b/lib/ood_core/cluster.rb
@@ -165,9 +165,9 @@ module OodCore
     # @return [Boolean, nil] whether cluster supports SSH to batch connect node
     def batch_connect_ssh_allow?
       return @batch_connect_ssh_allow if defined?(@batch_connect_ssh_allow)
-      return @batch_connect_ssh_allow = nil if batch_connect_config.nil?
+      return @batch_connect_ssh_allow = true if batch_connect_config.nil?
 
-      @batch_connect_ssh_allow = batch_connect_config.fetch(:ssh_allow, nil)
+      @batch_connect_ssh_allow = batch_connect_config.fetch(:ssh_allow, true)
     end
 
     # The comparison operator

--- a/spec/cluster_spec.rb
+++ b/spec/cluster_spec.rb
@@ -53,7 +53,7 @@ describe OodCore::Cluster do
       end
 
       it 'has default for batch_connect_ssh_allow?' do
-        expect(owens.batch_connect_ssh_allow?).to be_nil
+        expect(owens.batch_connect_ssh_allow?).to be true
       end
 
       it 'can enable batch_connect_ssh_allow?' do


### PR DESCRIPTION
Related to https://github.com/OSC/ondemand/pull/3206 - see specifically https://github.com/OSC/ondemand/pull/3206#discussion_r1406761692