### PR TITLE
add gpu awareness to queue_info

### DIFF
--- a/lib/ood_core/job/adapters/slurm.rb
+++ b/lib/ood_core/job/adapters/slurm.rb
@@ -327,13 +327,13 @@ module OodCore
 
             [].tap do |ret_arr|
               info_raw.each_line do |line|
-                ret_arr << str_to_acct_info(line)
+                ret_arr << str_to_queue_info(line)
               end
             end
           end
 
           private
-            def str_to_acct_info(line)
+            def str_to_queue_info(line)
               hsh = line.split(' ').map do |token|
                 m = token.match(/^(?<key>\w+)=(?<value>.+)$/)
                 [m[:key], m[:value]]
@@ -349,6 +349,7 @@ module OodCore
 
 
               hsh[:deny_accounts] = hsh[:DenyAccounts].nil? ? [] : hsh[:DenyAccounts].to_s.split(',')
+              hsh[:tres] = hsh[:TRES].nil? ? {} : hsh[:TRES].to_s.split(',').map { |str| str.split('=') }.to_h
 
               OodCore::Job::QueueInfo.new(**hsh)
             end

--- a/lib/ood_core/job/queue_info.rb
+++ b/lib/ood_core/job/queue_info.rb
@@ -20,9 +20,13 @@ class OodCore::Job::QueueInfo
   # The accounts that are not allowed to use this queue.
   attr_reader :deny_accounts
 
+  # An Hash of Trackable Resources and their values.
+  attr_reader :tres
+
   def initialize(**opts)
     @name = opts.fetch(:name, 'unknown')
     @qos = opts.fetch(:qos, [])
+    @tres = opts.fetch(:tres, {})
 
     allow_accounts = opts.fetch(:allow_accounts, nil)
     @allow_accounts = if allow_accounts.nil?
@@ -41,5 +45,9 @@ class OodCore::Job::QueueInfo
       name = var.to_s.gsub('@', '').to_sym
       [name, send(name)]
     end.to_h
+  end
+
+  def gpu?
+    tres.keys.any? { |name| name.to_s.match?(/gpu/i) }
   end
 end

--- a/lib/ood_core/job/queue_info.rb
+++ b/lib/ood_core/job/queue_info.rb
@@ -48,6 +48,6 @@ class OodCore::Job::QueueInfo
   end
 
   def gpu?
-    tres.keys.any? { |name| name.to_s.match?(/gpu/i) }
+    tres.keys.any? { |name| name.to_s.match?(%r{^gres/gpu($|:)}i) }
   end
 end

--- a/spec/job/adapters/slurm_spec.rb
+++ b/spec/job/adapters/slurm_spec.rb
@@ -1333,11 +1333,16 @@ describe OodCore::Job::Adapters::Slurm do
         expect(systems_queue.allow_accounts).to eq(['root', 'pzs0708', 'pzs0710', 'pzs0722'])
         expect(systems_queue.deny_accounts).to eq([])
         expect(systems_queue.qos).to eq([])
+        expect(systems_queue.gpu?).to eq(true)
 
         quick_queue = queues.select { |q| q.name == 'quick' }.first
         expect(quick_queue.allow_accounts).to eq(nil)
         expect(quick_queue.deny_accounts).to eq(quick_deny_accounts)
         expect(quick_queue.qos).to eq(['quick'])
+        expect(quick_queue.gpu?).to eq(false)
+
+        gpu_queue = queues.select { |q| q.name == 'gpuserial' }.first
+        expect(gpu_queue.gpu?).to eq(true)
       end
     end
 


### PR DESCRIPTION
add gpu awareness to queue_info so upper layers like OOD can make decisions on it.