### PR TITLE
Add configurable websocket heartbeat

### DIFF
--- a/lib/ood_core/batch_connect/templates/vnc.rb
+++ b/lib/ood_core/batch_connect/templates/vnc.rb
@@ -130,7 +130,8 @@ module OodCore
           # successful connections so that the password can be reset
           def after_script
             websockify_cmd = context.fetch(:websockify_cmd, "${WEBSOCKIFY_CMD:-/opt/websockify/run}").to_s
-
+            websockify_hb = context.fetch(:websockify_hb, "${WEBSOCKIFY_HB:-30}").to_s
+            
             <<-EOT.gsub(/^ {14}/, "")
               #{super}
 
@@ -139,7 +140,7 @@ module OodCore
               start_websockify() {
                 local log_file="./websockify.log"
                 # launch websockify in background and redirect all output to a file.
-                #{websockify_cmd} $1 $2 &> $log_file &
+                #{websockify_cmd} $1 --heartbeat=#{websockify_hb} $2 &> $log_file &
                 local ws_pid=$!
                 local counter=0
 


### PR DESCRIPTION
Without the --heartbeat option the VNC session will timeout after 1 minute of idle time. This adds --heartbeat with a default of 30 seconds, configurable with websockify_hb in the context or the environment variable WEBSOCKIFY_HB.

This implements the VNC timeout workaround mentioned in 
[VNC timeout](https://discourse.openondemand.org/t/novnc-and-shell-session-timeout-after-1-minute/1622)

The VNC app in OSC/ondemand will need to be updated to recognise the websockify_hb context variable.