### PR TITLE
systemd adapter fails with zsh as user shell

### DIFF
--- a/lib/ood_core/job/adapters/systemd/launcher.rb
+++ b/lib/ood_core/job/adapters/systemd/launcher.rb
@@ -204,7 +204,7 @@ class OodCore::Job::Adapters::LinuxSystemd::Launcher
 
   # List all Systemd sessions on destination_host started by this adapter
   def list_remote_systemd_session(destination_host)
-    cmd = ssh_cmd(destination_host, ['systemctl', '--user', 'show', '-t', 'service', '--state=running', "#{session_name_label}-*"])
+    cmd = ssh_cmd(destination_host, ['systemctl', '--user', 'show', '-t', 'service', '--state=running', "#{session_name_label}-\\*"])
 
     # individual units are separated with an empty line
     call(*cmd).split("\n\n").map do |oneunit|


### PR DESCRIPTION
zsh interprets the * in ondemand-* as a file path and returns an error if nothing is matched (unless the user has set 'setopt no_nomatch' in their .zshrc. Escape it to pass the asterisk on to systemctl (so it can be parsed internally).