### PR TITLE
Fix GPU Regex

### DIFF
--- a/lib/ood_core/job/adapters/slurm.rb
+++ b/lib/ood_core/job/adapters/slurm.rb
@@ -41,7 +41,7 @@ module OodCore
         # calculated from gres string
         # @return [Integer] the number of gpus in gres
         def self.gpus_from_gres(gres)
-          gres.to_s.scan(/gpu:[^,]*(\d+)/).flatten.map(&:to_i).sum
+          gres.to_s.scan(/gpu[^(,]*[:=](\d+)/).flatten.map(&:to_i).sum
         end
 
         # Object used for simplified communication with a Slurm batch server

--- a/spec/job/adapters/slurm_spec.rb
+++ b/spec/job/adapters/slurm_spec.rb
@@ -1216,7 +1216,11 @@ describe OodCore::Job::Adapters::Slurm do
         ["gres/gpu:v100-32g=2", 2],
         ["gres/gpu:v100-32g=2,gres/gpu:v100-32g=4", 6],
         ["gres/gpu:v100-32g=2,gres:gpu:1,gres/gpu:v100-32g=4", 7],
-        ["gres/gpu:v100-32g=2,gres:pfsdir:1", 2]
+        ["gres/gpu:v100-32g=2,gres:pfsdir:1", 2],
+        ["gpu:p100:1,nsight:no_consume:1", 1],
+        ["gpu:p100:1(IDX:0),mps:0", 1],
+        ["gpu:a100:4(S:0-15)", 4],
+        ["gpu:a100:3(IDX:0,2-3),mps:0", 3],
       ]
       gres_cases.each do |gc| 
         it "does not return the correct number of gpus when gres=\"#{gc[0]}\"" do


### PR DESCRIPTION
The number of active and total GPUs are counted incorrectly because the regular expression searching for GPUs is selecting the wrong number. Fix the regex to select the correct number of GPUs.