### PR TITLE
fix ffi dependency for ruby 2.5 and 2.7

### DIFF
--- a/ood_core.gemspec
+++ b/ood_core.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |spec|
   spec.required_ruby_version = ">= 2.5.0"
 
   spec.add_runtime_dependency "ood_support", "~> 0.0.2"
-  spec.add_runtime_dependency "ffi", "~> 1.9", ">= 1.9.6"
+  spec.add_runtime_dependency "ffi", "~> 1.16.3"
   spec.add_runtime_dependency "rexml", "~> 3.2"
   spec.add_development_dependency "bundler", "~> 2.1"
   spec.add_development_dependency "rake", "~> 13.2.0"


### PR DESCRIPTION
fix ffi dependency for ruby 2.5 and 2.7