### PR TITLE
add rake task for getting squeue text output

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -1,8 +1,8 @@
 require "bundler/gem_tasks"
 require "rspec/core/rake_task"
 
+require_relative 'lib/tasks/slurm'
+
 RSpec::Core::RakeTask.new(:spec)
 
 task :default => :spec
-
-require_relative 'lib/tasks/slurm'

--- a/Rakefile
+++ b/Rakefile
@@ -4,3 +4,5 @@ require "rspec/core/rake_task"
 RSpec::Core::RakeTask.new(:spec)
 
 task :default => :spec
+
+require_relative 'lib/tasks/slurm'

--- a/lib/tasks/slurm.rb
+++ b/lib/tasks/slurm.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+require_relative '../ood_core'
+require_relative '../ood_core/job/adapters/slurm'
+
+namespace :slurm do
+
+  desc 'Get squeue output in the format this gem expects'
+  task :squeue do
+    fields = OodCore::Job::Adapters::Slurm::Batch.new.all_squeue_fields
+    args = OodCore::Job::Adapters::Slurm::Batch.new.squeue_args(options: fields.values)
+
+    single_job = `squeue #{args.join(' ')}`.split("\n")[0...2]
+
+    puts single_job
+  end
+end


### PR DESCRIPTION
I went to write a test case for squeue in slurm and needed some squeue output to test against. Given that we expect the output to be of a certain format, this was very hard to do by hand.

So I've written this rake task to output 1 single job from squeue -  in the format that this library expects - to write to a fixture file that we can then test against. 