### PR TITLE
remove support for Ruby 2.5

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby: ["2.5.1", "2.7.1"]
+        ruby: ["2.7.1"]
         bundler: ["2.1.4"]
         include:
           - ruby: "3.0.2"


### PR DESCRIPTION
remove support for Ruby 2.5 because OnDemand at this time doesn't support any operating system that uses Ruby 2.5.