### PR TITLE
fix ERB.new to remove deprecation warnings

### DIFF
--- a/lib/ood_core/job/adapters/kubernetes/batch.rb
+++ b/lib/ood_core/job/adapters/kubernetes/batch.rb
@@ -239,7 +239,7 @@ class OodCore::Job::Adapters::Kubernetes::Batch
     node_selector = native_data[:node_selector].nil? ? {} : native_data[:node_selector]
     gpu_type = native_data[:gpu_type].nil? ? "nvidia.com/gpu" : native_data[:gpu_type]
 
-    template = ERB.new(File.read(resource_file), nil, '-')
+    template = ERB.new(File.read(resource_file), trim_mode: '-')
 
     [template.result(binding), id]
   end


### PR DESCRIPTION
fix ERB.new to remove deprecation warnings.

The warnings in question are these 2:
```
/users/PZS0714/johrstrom/ondemand/misc/core/lib/ood_core/job/adapters/kubernetes/batch.rb:242: warning: Passing safe_level with the 2nd argument of ERB.new is deprecated. Do not use it, and specify other arguments as keyword arguments.
/users/PZS0714/johrstrom/ondemand/misc/core/lib/ood_core/job/adapters/kubernetes/batch.rb:242: warning: Passing trim_mode with the 3rd argument of ERB.new is deprecated. Use keyword argument like ERB.new(str, trim_mode: ...) instead.
```