### PR TITLE
add support for specifying cores for the adapters that can support it

### DIFF
--- a/lib/ood_core/job/adapters/lsf/helper.rb
+++ b/lib/ood_core/job/adapters/lsf/helper.rb
@@ -91,6 +91,7 @@ class OodCore::Job::Adapters::Lsf::Helper
     args.concat ["-b", script.start_time.localtime.strftime("%Y:%m:%d:%H:%M")] unless script.start_time.nil?
     args.concat ["-W", (script.wall_time / 60).to_i] unless script.wall_time.nil?
     args.concat ["-L", script.shell_path.to_s] unless script.shell_path.nil?
+    args.concat ['-n', script.cores] unless script.cores.nil?
 
     # environment
     env = script.job_environment || {}

--- a/lib/ood_core/job/adapters/pbspro.rb
+++ b/lib/ood_core/job/adapters/pbspro.rb
@@ -269,6 +269,7 @@ module OodCore
           args.concat ["-a", script.start_time.localtime.strftime("%C%y%m%d%H%M.%S")] unless script.start_time.nil?
           args.concat ["-A", script.accounting_id] unless script.accounting_id.nil?
           args.concat ["-l", "walltime=#{seconds_to_duration(script.wall_time)}"] unless script.wall_time.nil?
+          ars.concat  ppn(script)
 
           # Set dependencies
           depend = []
@@ -420,6 +421,13 @@ module OodCore
 
         def directive_prefix
           '#PBS'
+        end
+
+        # place holder for when we support both nodes and cpus.
+        def ppn(script)
+          return [] if script.cores.nil?
+
+          ['-l', "ncpus=#{script.cpus}"]
         end
 
         private

--- a/lib/ood_core/job/adapters/slurm.rb
+++ b/lib/ood_core/job/adapters/slurm.rb
@@ -526,6 +526,7 @@ module OodCore
           args.concat ['-a', script.job_array_request] unless script.job_array_request.nil?
           args.concat ['--qos', script.qos] unless script.qos.nil?
           args.concat ['--gpus-per-node', script.gpus_per_node] unless script.gpus_per_node.nil?
+          args.concat ['-n', script.cores] unless script.cores.nil?
           # ignore nodes, don't know how to do this for slurm
 
           # Set dependencies

--- a/lib/ood_core/job/adapters/torque.rb
+++ b/lib/ood_core/job/adapters/torque.rb
@@ -160,6 +160,7 @@ module OodCore
             args.concat ['-t', script.job_array_request] unless script.job_array_request.nil?
             args.concat ['-l', "qos=#{script.qos}"] unless script.qos.nil?
             args.concat ['-l', "gpus=#{script.gpus_per_node}"] unless script.gpus_per_node.nil?
+            args.concat ppn(script)
 
             # Set environment variables
             env = script.job_environment.to_h
@@ -300,6 +301,13 @@ module OodCore
 
         def directive_prefix
           '#QSUB'
+        end
+
+        # place holder for when we support both nodes and cpus.
+        def ppn(script)
+          return [] if script.cores.nil?
+
+          ['-l', "procs=#{script.cpus}"]
         end
 
         private

--- a/lib/ood_core/job/script.rb
+++ b/lib/ood_core/job/script.rb
@@ -108,6 +108,10 @@ module OodCore
       # @return [Integer, nil] gpus per node
       attr_reader :gpus_per_node
 
+      # The core request for this job
+      # @return [Integer, nil] cores
+      attr_reader :cores
+
       # Object detailing any native specifications that are implementation specific
       # @note Should not be used at all costs.
       # @return [Object, nil] native specifications
@@ -151,7 +155,8 @@ module OodCore
                      output_path: nil, error_path: nil, reservation_id: nil,
                      queue_name: nil, priority: nil, start_time: nil,
                      wall_time: nil, accounting_id: nil, job_array_request: nil,
-                     qos: nil, gpus_per_node: nil, native: nil, copy_environment: nil, **_)
+                     qos: nil, gpus_per_node: nil, native: nil, copy_environment: nil,
+                     cores: nil, **_)
         @content = content.to_s
 
         @submit_as_hold      = submit_as_hold
@@ -179,6 +184,7 @@ module OodCore
         @gpus_per_node      = gpus_per_node     && gpus_per_node.to_i
         @native             = native
         @copy_environment   = (copy_environment.nil?) ? nil : !! copy_environment
+        @cores              = cores&.to_i
       end
 
       # Convert object to hash
@@ -209,7 +215,8 @@ module OodCore
           qos:                 qos,
           gpus_per_node:       gpus_per_node,
           native:              native,
-          copy_environment:    copy_environment
+          cores:               cores,
+          copy_environment:    copy_environment,
         }
       end
 


### PR DESCRIPTION
Add support for specifying cores for the adapters that can support it.

Fujitsu and SGE don't have support for this yet.  SGE seems to need a variable to specify the parallel environment, which is unknown upfront. We'd have to issue a `qconf` command or similar to find the applicable string to use.  Fujitsu I just can't seem to find the documentation for it.

I'll keep this open for just a second to write some tests for it.
