### PR TITLE
Add singularity_options to the native structure.

### DIFF
--- a/lib/ood_core/job/adapters/linux_host/launcher.rb
+++ b/lib/ood_core/job/adapters/linux_host/launcher.rb
@@ -170,6 +170,7 @@ class OodCore::Job::Adapters::LinuxHost::Launcher
         'script_timeout' => script_timeout(script),
         'session_name' => session_name,
         'singularity_bin' => singularity_bin,
+        'singularity_options' => singularity_options(script.native),
         'singularity_image' => singularity_image(script.native),
         'ssh_hosts' => ssh_hosts,
         'tmux_bin' => tmux_bin,
@@ -203,6 +204,12 @@ class OodCore::Job::Adapters::LinuxHost::Launcher
     return site_singularity_bindpath unless native && native[:singularity_bindpath]
 
     native[:singularity_bindpath]
+  end
+
+  def singularity_options(native)
+    return '' unless native && native[:singularity_options]
+
+    native[:singularity_options]
   end
 
   def script_timeout(script)

--- a/lib/ood_core/job/adapters/linux_host/templates/script_wrapper.erb.sh
+++ b/lib/ood_core/job/adapters/linux_host/templates/script_wrapper.erb.sh
@@ -47,7 +47,7 @@ trap exit_script SIGINT SIGTERM
 OUTPUT_PATH=<%= output_path %>
 ERROR_PATH=<%= error_path %>
 ({
-timeout <%= script_timeout %>s <%= singularity_bin %> exec <%= contain %> --pid <%= singularity_image %> /bin/bash --login $singularity_tmp_file <%= arguments %>
+timeout <%= script_timeout %>s <%= singularity_bin %> exec <%= singularity_options %> <%= contain %> --pid <%= singularity_image %> /bin/bash --login $singularity_tmp_file <%= arguments %>
 } | tee "$OUTPUT_PATH") 3>&1 1>&2 2>&3 | tee "$ERROR_PATH"
 
 <%= email_on_terminated %>


### PR DESCRIPTION
This allows containers launch specs to specify additional options for Singularity such as --nv for nVIDIA GPU and --rocm for AMD GPU or --bind /etc/OpenCL for OpenCL (in combination with one of the prior).

Example:
script:
  native:
    singularity_bindpath: /tmp,/home,/mnt,/run
    singularity_bin: /usr/bin/singularity
    singularity_container: "/opt/ood/images/nvidia-parabricks.sif"
    singularity_options: "--nv"
    
Will allow Parabricks to run with nVIDIA GPU.