### PR TITLE
SSH Keyfile location support for systemd launcher/cluster

### DIFF
--- a/lib/ood_core/job/adapters/systemd.rb
+++ b/lib/ood_core/job/adapters/systemd.rb
@@ -15,6 +15,7 @@ module OodCore
       # @option config [Object] :ssh_hosts (nil) The list of permissable hosts, defaults to :submit_host
       # @option config [Object] :strict_host_checking (true) Set to false to disable strict host checking and updating the known_hosts file
       # @option config [Object] :submit_host The SSH target to connect to, may be the head of a round-robin
+      # @option config [Object] :ssh_keyfile The SSH Key file to use as identity.
       def self.build_systemd(config)
         c = config.to_h.symbolize_keys
         debug = c.fetch(:debug, false)
@@ -22,6 +23,7 @@ module OodCore
         ssh_hosts = c.fetch(:ssh_hosts, [c[:submit_host]])
         strict_host_checking = c.fetch(:strict_host_checking, true)
         submit_host = c[:submit_host]
+        ssh_keyfile = c.fetch(:ssh_keyfile, "")
 
         Adapters::LinuxSystemd.new(
           ssh_hosts: ssh_hosts,
@@ -31,6 +33,7 @@ module OodCore
             ssh_hosts: ssh_hosts,
             strict_host_checking: strict_host_checking,
             submit_host: submit_host,
+            ssh_keyfile: ssh_keyfile,
           )
         )
       end

--- a/lib/ood_core/job/adapters/systemd/launcher.rb
+++ b/lib/ood_core/job/adapters/systemd/launcher.rb
@@ -131,9 +131,6 @@ class OodCore::Job::Adapters::LinuxSystemd::Launcher
 
   end
 
-
-  end
-
   def shell
     ENV['SHELL'] || '/bin/bash'
   end

--- a/lib/ood_core/job/adapters/systemd/launcher.rb
+++ b/lib/ood_core/job/adapters/systemd/launcher.rb
@@ -106,26 +106,33 @@ class OodCore::Job::Adapters::LinuxSystemd::Launcher
   # @param cmd [Array<#to_s>] the command to be executed on the destination host
   def ssh_cmd(destination_host, cmd)
 
-    basecmd=[
+  def ssh_cmd(destination_host, cmd)
+
+    sshcmd=[
       'ssh', '-t',
       '-p', OodCore::Job::Adapters::Helper.ssh_port,
       '-o', 'Batchmode=yes',
-      "#{username}@#{destination_host}",
-    ].concat(cmd)
+    ]
 
     if !strict_host_checking
-      basecmd.insert(4, '-o')
-      basecmd.insert(5, 'StrictHostKeyChecking=no')
-      basecmd.insert(4, '-o')
-      basecmd.insert(5, 'UserKnownHostsFile=/dev/null')
+      sshcmd.concat([
+        '-o','StrictHostKeyChecking=no',
+        '-o','UserKnownHostsFile=/dev/null',
+      ])
     end
 
     if (!ssh_keyfile.to_s.empty?)
-      basecmd.insert(4, '-i')
-      basecmd.insert(5, ssh_keyfile.to_s)
+      sshcmd.concat([
+        '-i',ssh_keyfile.to_s,
+      ])
     end
 
-   return basecmd
+    sshcmd.concat([
+      "#{username}@#{destination_host}"
+    ]).concat(cmd)
+
+  end
+
 
   end
 

--- a/lib/ood_core/job/adapters/systemd/launcher.rb
+++ b/lib/ood_core/job/adapters/systemd/launcher.rb
@@ -106,8 +106,6 @@ class OodCore::Job::Adapters::LinuxSystemd::Launcher
   # @param cmd [Array<#to_s>] the command to be executed on the destination host
   def ssh_cmd(destination_host, cmd)
 
-  def ssh_cmd(destination_host, cmd)
-
     sshcmd=[
       'ssh', '-t',
       '-p', OodCore::Job::Adapters::Helper.ssh_port,


### PR DESCRIPTION
This should give some (albeit poor quality) support for alternative ssh keyfile locations using the systemd launcher.

Our use case is so users don't have to think about ssh key generation etc to reduce a barrier of entry.

I don't write ruby so this is probably a mess.