### PR TITLE
Handle (null) tres in str_to_queue_info.

### DIFF
--- a/lib/ood_core/job/adapters/slurm.rb
+++ b/lib/ood_core/job/adapters/slurm.rb
@@ -372,10 +372,14 @@ module OodCore
                                        hsh[:AllowAccounts].to_s.split(',')
                                      end
 
-
               hsh[:deny_accounts] = hsh[:DenyAccounts].nil? ? [] : hsh[:DenyAccounts].to_s.split(',')
-              hsh[:tres] = hsh[:TRES].nil? ? {} : hsh[:TRES].to_s.split(',').map { |str| str.split('=') }.to_h
 
+              hsh[:tres] = case hsh[:TRES]
+                           when nil, '(null)', ''
+                             {}
+                           else
+                             hsh[:TRES].to_s.split(',').map { |str| str.split('=') }.to_h
+                           end
               OodCore::Job::QueueInfo.new(**hsh)
             end
 


### PR DESCRIPTION
If a partition has TRES=(null), the parsing in str_to_queue_info fails and auto_queues is not available. This change explicitly handles the (null) case and maps to {}, effectively avoiding the failure.