### PR TITLE
avoid pipefail issue with `create_passwd`

### DIFF
--- a/lib/ood_core/batch_connect/template.rb
+++ b/lib/ood_core/batch_connect/template.rb
@@ -209,9 +209,10 @@ module OodCore
                 export -f wait_until_port_used
 
                 # Generate random alphanumeric password with $1 (default: #{password_size}) characters
-                create_passwd () {
+                create_passwd () (
+                  set +o pipefail # ensure pipefail disabled, `head` closing stdin causes SIGPIPE
                   tr -cd 'a-zA-Z0-9' < /dev/urandom 2> /dev/null | head -c${1:-#{password_size}}
-                }
+                )
                 export -f create_passwd
               }
               export -f source_helpers


### PR DESCRIPTION
if you want to use [bash "strict mode"](http://redsymbol.net/articles/unofficial-bash-strict-mode/) in a batch connect job, you might be confused when your job fails.

```shell
#!/bin/bash
set -euo pipefail
set -x
password="$(generate_passwd)
echo "hello, world!"
```
`output.log`:
```console
++ tr -cd '[:alnum:]'
++ head -c16
+ password=IhZj0VloAJ4r0FwN
```

`create_passwd` successfully creates a password, but since `head` closes its `stin` while `tr` is still trying to write into it, `tr` gets a `SIGPIPE` and proces a return code = `128 + SIGPIPE = 141`. `set -o pipefail` means that the first nonzero exit code of any process in the pipeline is used for the whole pipeline, and `set -e` means that execution stops after the 1st nonzero exit code.

To prevent this, make sure that `pipefail` is disabled for `create_passwd`. To avoid changing the option in the original shell, `check_passwd` runs in a subshell (`()` instead of `{}`). subshell behavior tested:
```shell
$ set -o pipefail; set -o | grep pipefail; (set +o pipefail; set -o | grep pipefail); set -o | grep pipefail
pipefail       	on
pipefail       	off
pipefail       	on
```