### PR TITLE
Abstract job scheduler interface with PSI/J

### DIFF
--- a/lib/ood_core/job/adapters/psij.rb
+++ b/lib/ood_core/job/adapters/psij.rb
@@ -208,6 +208,9 @@ module OodCore
                         cpu_cores_per_process: script.cores}
           }
 
+          if params[:attributes][:queue_name].nil?
+            params[:attributes][:queue_name] = @psij.queue_name
+          end
           if params[:stdout_path].nil?
             params[:stdout_path] = File.join(Dir.pwd, "stdout.txt")
           end

--- a/lib/ood_core/job/adapters/psij.rb
+++ b/lib/ood_core/job/adapters/psij.rb
@@ -1,0 +1,407 @@
+require "time"
+require 'etc'
+require "ood_core/refinements/hash_extensions"
+require "ood_core/refinements/array_extensions"
+require "ood_core/job/adapters/helper"
+
+require 'json'
+require 'pathname'
+
+module OodCore
+  module Job
+		class Factory
+ 
+      using Refinements::HashExtensions
+			# Build the PSIJ adapter from a configuration
+      # @param config [#to_h] the configuration for job adapter
+      # @option config [Object] :bin (nil) Path to PSIJ binaries
+      # @option config [#to_h]  :bin_overrides ({}) Optional overrides to PSIJ executables
+			def self.build_psij(config)
+        c = config.to_h.symbolize_keys
+        cluster              = c.fetch(:cluster, nil)
+        conf                 = c.fetch(:conf, nil)
+        bin                  = c.fetch(:bin, nil)
+        bin_overrides        = c.fetch(:bin_overrides, {})
+        submit_host          = c.fetch(:submit_host, "")
+        strict_host_checking = c.fetch(:strict_host_checking, true)
+        executor             = c.fetch(:executor, nil)
+        queue_name           = c.fetch(:queue_name, nil)
+        psij = Adapters::PSIJ::Batch.new(cluster: cluster, conf: conf, bin: bin, bin_overrides: bin_overrides, submit_host: submit_host, strict_host_checking: strict_host_checking, executor: executor, queue_name: queue_name)
+        Adapters::PSIJ.new(psij: psij)
+      end
+		end
+
+		module Adapters
+      class PSIJ < Adapter
+        using Refinements::HashExtensions
+        using Refinements::ArrayExtensions
+        class Batch
+
+          attr_reader :cluster
+          attr_reader :conf
+          attr_reader :bin
+          attr_reader :bin_overrides
+          attr_reader :submit_host
+          attr_reader :strict_host_checking
+          attr_reader :executor
+          attr_reader :queue_name
+
+          class Error < StandardError; end
+
+          def initialize(cluster: nil, bin: nil, conf: nil, bin_overrides: {}, submit_host: "", strict_host_checking: true, executor: nil, queue_name: nil)
+            @cluster              = cluster && cluster.to_s
+            @conf                 = conf    && Pathname.new(conf.to_s)
+            @bin                  = Pathname.new(bin.to_s)
+            @bin_overrides        = bin_overrides
+            @submit_host          = submit_host.to_s
+            @strict_host_checking = strict_host_checking
+            @executor             = executor
+            @queue_name           = queue_name
+          end
+
+          def get_jobs(id: "", owner: nil)
+            id = id.to_s.strip()
+            params = {
+              id: id,
+              executor: executor,
+            }
+            args = params.map { |k, v| "--#{k}=#{v}" }
+            get_info_path = Pathname.new(__FILE__).dirname.expand_path.join("psij/get_info.py").to_s
+            jobs_data = call("python3", get_info_path, *args)
+            jobs_data = JSON.parse(jobs_data, symbolize_names: true)
+            jobs_data
+          end
+
+          def submit_job_path(args: [], chdir: nil, stdin: nil)
+            submit_path = Pathname.new(__FILE__).dirname.expand_path.join("psij/submit.py").to_s
+            call("python3", submit_path, *args, chdir: chdir, stdin: stdin)
+          end
+
+          def delete_job(args: [])
+            delete_path = Pathname.new(__FILE__).dirname.expand_path.join("psij/delete.py").to_s
+            call("python3", delete_path, *args)
+          rescue => e
+            raise JobAdapterError, e
+          end
+
+          def hold_job(args: [])
+            hold_path = Pathname.new(__FILE__).dirname.expand_path.join("psij/hold.py").to_s
+            call("python3", hold_path, *args)
+          end
+
+          def release_job(args: [])
+            release_path = Pathname.new(__FILE__).dirname.expand_path.join("psij/release.py").to_s
+            call("python3", release_path, *args)
+          end
+
+          def seconds_to_duration(time)
+            "%02d:%02d:%02d" % [time/3600, time/60%60, time%60]
+          end
+
+          private
+            # Call a forked psij script for a given cluster
+            def call(cmd, *args, env: {}, stdin: "", chdir: nil)
+              cmd = OodCore::Job::Adapters::Helper.bin_path(cmd, bin, bin_overrides)
+              cmd, args = OodCore::Job::Adapters::Helper.ssh_wrap(submit_host, cmd, args, strict_host_checking)
+              chdir ||= "."
+              o, e, s = Open3.capture3(env, cmd, *(args.map(&:to_s)), stdin_data: stdin, chdir: chdir.to_s)
+              s.success? ? o : raise(Error, e)
+            end
+
+        end
+        
+
+        STATE_MAP = {
+          'NEW'           => :undetermined,
+          'QUEUED'        => :queued,
+          'HELD'          => :queued_held,
+          'ACTIVE'        => :running,
+          'COMPLETED'     => :completed,
+        }
+
+        def initialize(opts = {})
+          o = opts.to_h.symbolize_keys
+        
+          @psij = o.fetch(:psij) { raise ArgumentError, "No psij object specified. Missing argument: psij" }
+        end
+        
+
+        # The `submit` method saves a job script as a file and prepares a command to submit the job.
+        # Each optional argument specifies job dependencies (after, afterok, afternotok, afterany).
+        def submit(script, after: [], afterok: [], afternotok: [], afterany: [])
+          # convert OOD interfaces to PSI/J interfaces.
+          # Conterted variables are shown as follows:
+          #       OOD           |   PSI/J(JobSpec)
+          # --------------------+----------------------------------------------------
+          # submit_as_hold      |       X (not support)
+          # rerunnable          |       X
+          # email_on_started    |       X
+          # email_on_terminated |       X
+          # args                |   JobAttributes.custom_attributes
+          # job_environment     |   environment
+          # workdir             |   directory
+          # email               |       X
+          # job_name            |   name
+          # shell_path          |   #!<shell_path>
+          # input_path          |   stdin_path
+          # output_path         |   stdout_path
+          # error_path          |   stderr_path
+          # reservation_id      |   JobAttributes.reservation_id
+          # queue_name          |   JobAttributes.queue_name
+          # priority            |       X
+          # start_time          |       X
+          # wall_time           |   JobAttributes.duration
+          # accounting_id       |   JobAttributes.account or project_name(duplicated)
+          # job_array_request   |       X
+          # qos                 |       X
+          # gpus_per_node       |   ResourceSpec.gpu_cores_per_process
+          # native              |   executable (join script.content)
+          # copy_environment    |   inherit_envrionment
+          # cores               |   ResourceSpec.cpu_cores_per_process
+          # after               |       X
+          # afterok             |       X
+          # afternotok          |       X
+          # afterany            |       X
+          # OOD does not have following PSI/J's interfaces.
+          #   JobSpec class:
+          #     pre_launch, post_launch, launcher
+          #   ResourceSpec class:
+          #     node_count, process_count, processes_per_node, exclusive_node_use
+
+          content = if script.shell_path.nil?
+            script.content
+          else
+            "#!#{script.shell_path}\n#{script.content}"
+          end
+
+          if ! script.native.nil?
+            native = script.native.join("\n") unless script.native.nil?
+            script.content.concat(native)
+          end
+
+          relative_path = "~/ood_tmp/run.sh"
+          full_path = File.expand_path("~/ood_tmp/run.sh")
+          FileUtils.mkdir_p(File.dirname(full_path))
+          File.open(full_path, "w") do |file|
+            file.write(content)
+          end
+
+          File.chmod(0755, full_path)
+
+          # convert OOD interfaces to PSI/J interfaces.
+          params = {
+            environment: script.job_environment,
+            directory: script.workdir,
+            name: script.job_name,
+            executable: relative_path,
+            stdin_path: script.input_path,
+            stdout_path: script.output_path,
+            stderr_path: script.error_path,
+            inherit_environment: script.copy_environment,
+            attributes: {queue_name: script.queue_name,
+                         reservation_id: script.reservation_id,
+                         account: script.accounting_id,
+                         duration: script.wall_time,
+                         custom_attributes: script.args},
+            resources: {__version: 1,
+                        gpu_cores_per_process: script.gpus_per_node,
+                        cpu_cores_per_process: script.cores}
+          }
+
+          if params[:stdout_path].nil?
+            params[:stdout_path] = File.join(Dir.pwd, "stdout.txt")
+          end
+          if params[:stderr_path].nil?
+            params[:stderr_path] = File.join(Dir.pwd, "stderr.txt")
+          end
+
+          # add script.native to params[:attributes][:custom_attributes] of PSI/J.
+          if script.native && !script.native.empty?
+            if params[:attributes][:custom_attributes].nil?
+              params[:attributes][:custom_attributes] = script.native
+            else
+              params[:attributes][:custom_attributes].concat(script.native)
+            end
+          end
+          # Add script.native to params[:attributes][:cutsom_attributes] of PSI/J.
+          # Convert script.native array to hash.
+          # ['--<name>', 'value'] -> {name: value}
+          # ['--<name1>', '--<name2>'] -> {name1: "", name2: ""}
+          if ! params[:attributes][:custom_attributes].nil? 
+            hash = {}
+            skip = false
+            len = params[:attributes][:custom_attributes].length()-1
+            for index in 0..len do
+              if skip
+                skip = false
+                next
+              end
+              v = params[:attributes][:custom_attributes][index]
+              has_hyphen = false
+              if v.start_with?("--")
+                name = v[2..-1]
+                has_hyphen = true
+              elsif v.start_with?("-")
+                name = v[1..-1]
+                has_hyphen = true
+              else   
+                name = v
+              end
+              if index == len || !has_hyphen || params[:attributes][:custom_attributes][index+1].start_with?("-")
+                # if next value is not exist or start with "-", set empty string
+                hash[name] = ""
+              else
+                # if next value is exist and not start with "-", set value
+                hash[name] = params[:attributes][:custom_attributes][index+1]
+                skip = true
+              end
+            end
+            params[:attributes][:custom_attributes] = hash
+          end
+
+          # reject key which has nil value.
+          params[:attributes] = params[:attributes].reject {|_, value |value.nil?}
+          params[:resources] = params[:resources].reject {|_, value |value.nil?}
+          data = params.reject {|_, value |value.nil?}
+          
+          # serialize params to JSON
+          args = []
+          args[0] = @psij.executor
+
+          @psij.submit_job_path(args: args, chdir: script.workdir, stdin: JSON.generate(data))
+        rescue Batch::Error => e
+          raise JobAdapterError, e
+        end
+
+        def cluster_info
+        end
+
+        def accounts
+        end
+        
+        def delete(id)
+          id = id.to_s.strip()
+          params = {
+            id: id,
+            executor: @psij.executor,
+          }
+          args = params.map { |k, v| "--#{k}=#{v}" }
+          @psij.delete_job(args: args)
+        rescue Batch::Error => e
+          raise JobAdapterError, e.message unless /Invalid job id specified/ =~ e.message
+        end
+
+        def hold(id)
+          id = id.to_s.strip()
+          params = {
+            id: id,
+            executor: @psij.executor,
+          }
+          args = params.map { |k, v| "--#{k}=#{v}" }
+          @psij.hold_job(args: args)
+        rescue Batch::Error => e
+          raise JobAdapterError, e.message unless /Invalid job id specified/ =~ e.message
+        end
+
+        def release(id)
+          id = id.to_s.strip()
+          params = {
+            id: id,
+            executor: @psij.executor,
+          }
+          args = params.map { |k, v| "--#{k}=#{v}" }
+          @psij.release_job(args: args)
+        rescue Batch::Error => e
+          raise JobAdapterError, e.message unless /Invalid job id specified/ =~ e.message
+        end
+
+
+        def info(id)
+          id = id.to_s
+
+          job_infos = @psij.get_jobs(id: id).map do |v|
+            parse_job_info(v)
+          end
+
+          if job_infos.empty?
+            Info.new(id: id, status: :completed)
+          else
+            job_infos.first
+          end
+        rescue Batch::Error => e
+          # set completed status if can't find job id
+          if /Invalid job id specified/ =~ e.message
+            Info.new(
+              id: id,
+              status: :completed
+            )
+          else
+            raise JobAdapterError, e.message
+          end
+        end
+
+        def info_all(attrs: nil)
+          @psij.get_jobs.map do |v|
+            parse_job_info(v)
+          end
+        rescue Batch::Error => e
+          raise JobAdapterError, e.message
+        end
+
+        def info_where_owner(owner, attrs: nil)
+          owner = Array.wrap(owner).map(&:to_s).join(',')
+          @psij.get_jobs(owner: owner).map do |v|
+            parse_job_info(v)
+          end
+        rescue Batch::Error => e
+          raise JobAdapterError, e.message
+        end
+
+        def status(id)
+          info(id.to_s).status
+        end
+
+        def directive_prefix
+        end
+
+        private
+          def get_state(st)
+            STATE_MAP.fetch(st, :undetermined)
+          end
+
+          def parse_job_info(v)
+            # parse input hash to Info object
+            # if v don't have :reosurcelist, set empty array
+            if v[:resourcelist].nil? || v[:resourcelist].empty?
+              allocated_nodes = [ { name: "" } ]
+            else
+              allocated_nodes = v[:resourcelist]
+            end
+            if v[:cpu_time].nil?
+              cpu_time = nil
+            else
+              cpu_time = v[:cpu_time].to_i
+            end
+            Info.new(
+              id: v[:native_id],
+              status: get_state(v[:current_state]),
+              allocated_nodes: allocated_nodes,
+              submit_host: v[:submit_host],
+              job_name: v[:name],
+              job_owner: v[:owner],
+              accounting_id: v[:account],
+              procs: v[:process_count] ? v[:process_count].to_i : 0,
+              queue_name: v[:queue_name],
+              wallclock_time: v[:wall_time],
+              wallclock_limit: v[:duration],
+              cpu_time: cpu_time,
+              submission_time: v[:submission_time] ? Time.parse(v[:submission_time]): nil,
+              dispatch_time: v[:dispatch_time] ? Time.parse(v[:dispatch_time]): nil,
+              native: v
+            )
+          end
+
+      end
+    end
+  end
+end

--- a/lib/ood_core/job/adapters/psij/delete.py
+++ b/lib/ood_core/job/adapters/psij/delete.py
@@ -1,0 +1,18 @@
+import argparse
+
+parser = argparse.ArgumentParser(description="Process job parameters")
+parser.add_argument("--id", type=str, required=True, help="Path to the job script")
+parser.add_argument("--executor", type=str, required=True, help="Executor to be used")
+
+args = parser.parse_args()
+
+from psij import Job, JobExecutor
+
+ex = JobExecutor.get_instance(args.executor)
+job = Job()
+job._native_id = args.id
+# catch exception
+try:
+  ex.cancel(job)
+except Exception as e:
+  print(f"Invalid job id specified")

--- a/lib/ood_core/job/adapters/psij/get_info.py
+++ b/lib/ood_core/job/adapters/psij/get_info.py
@@ -1,0 +1,52 @@
+import argparse
+import json
+from datetime import datetime, timedelta
+import time
+
+parser = argparse.ArgumentParser(description="Process job parameters")
+parser.add_argument("--id", type=str, help="Path to the job script")
+parser.add_argument("--owner", type=str, help="the name of job owner")
+parser.add_argument("--executor", type=str, required=True, help="Executor to be used")
+
+args = parser.parse_args()
+
+from psij import Job, JobExecutor
+from psij.serialize import JSONSerializer
+
+ex = JobExecutor.get_instance(args.executor)
+if args.id:
+    job = Job()
+    job._native_id = args.id
+    job_data = ex.info([job])
+elif args.owner:
+    job_data = ex.info(owner=args.owner)
+else:
+    job_data = ex.info()
+
+s = JSONSerializer()
+# create dict for each job.
+# [ {'native_id': native_id, ... }, {'native_id': native_id, ...}, ...]
+data = []
+for job in job_data:
+    d = {}
+    d["native_id"] = job.native_id
+    d["current_state"] = job._status.state.name
+    d.update(job.current_info.__dict__)
+    d.update(s._from_spec(job.spec))
+    # the attributes and resources are nested in the job data.
+    # we need to flatten them.
+    attr = d["attributes"]
+    del d["attributes"]
+    # convert deltatime or string to integer
+    d["duration"] = job.spec.attributes.duration.total_seconds()
+    d["wall_time"] = int(d["wall_time"])
+    d.update(attr)
+    resources = d["resources"]
+    del d["resources"]
+    d.update(resources)
+    d["submission_time"] = d["submission_time"].strftime("%Y-%m-%d %H:%M:%S")
+    d["dispatch_time"] = d["dispatch_time"].strftime("%Y-%m-%d %H:%M:%S")
+
+    data.append(d)
+
+print(json.dumps(data))

--- a/lib/ood_core/job/adapters/psij/get_info.py
+++ b/lib/ood_core/job/adapters/psij/get_info.py
@@ -37,15 +37,18 @@ for job in job_data:
     # we need to flatten them.
     attr = d["attributes"]
     del d["attributes"]
+    d.update(attr)
     # convert deltatime or string to integer
     d["duration"] = job.spec.attributes.duration.total_seconds()
     d["wall_time"] = int(d["wall_time"])
-    d.update(attr)
     resources = d["resources"]
     del d["resources"]
     d.update(resources)
     d["submission_time"] = d["submission_time"].strftime("%Y-%m-%d %H:%M:%S")
-    d["dispatch_time"] = d["dispatch_time"].strftime("%Y-%m-%d %H:%M:%S")
+    if d["dispatch_time"] is not None:
+      d["dispatch_time"] = d["dispatch_time"].strftime("%Y-%m-%d %H:%M:%S")
+    else:
+      d["dispatch_time"] = None
 
     data.append(d)
 

--- a/lib/ood_core/job/adapters/psij/hold.py
+++ b/lib/ood_core/job/adapters/psij/hold.py
@@ -1,0 +1,18 @@
+import argparse
+
+parser = argparse.ArgumentParser(description="Process job parameters")
+parser.add_argument("--id", type=str, required=True, help="Path to the job script")
+parser.add_argument("--executor", type=str, required=True, help="Executor to be used")
+
+args = parser.parse_args()
+
+from psij import Job, JobExecutor
+
+ex = JobExecutor.get_instance(args.executor)
+job = Job()
+job._native_id = args.id
+# catch exception
+try:
+  ex.hold(job)
+except Exception as e:
+  print(f"Invalid job id specified")

--- a/lib/ood_core/job/adapters/psij/release.py
+++ b/lib/ood_core/job/adapters/psij/release.py
@@ -1,0 +1,18 @@
+import argparse
+
+parser = argparse.ArgumentParser(description="Process job parameters")
+parser.add_argument("--id", type=str, required=True, help="Path to the job script")
+parser.add_argument("--executor", type=str, required=True, help="Executor to be used")
+
+args = parser.parse_args()
+
+from psij import Job, JobExecutor
+
+ex = JobExecutor.get_instance(args.executor)
+job = Job()
+job._native_id = args.id
+# catch exception
+try:
+  ex.release(job)
+except Exception as e:
+  print(f"Invalid job id specified")

--- a/lib/ood_core/job/adapters/psij/submit.py
+++ b/lib/ood_core/job/adapters/psij/submit.py
@@ -1,0 +1,28 @@
+import sys
+from psij import Job, JobExecutor
+from psij.serialize import JSONSerializer
+from pathlib import Path
+import json
+import os
+
+# create executor instance.
+ex = JobExecutor.get_instance(sys.argv[1])
+
+# deserialize json data to job spec.
+deserialize = JSONSerializer()
+d = sys.stdin.read()
+j = json.loads(d)
+spec = deserialize._to_spec(j)
+
+# add executor string to each key of custom attributes.
+if sys.argv[1] != "local" and spec.attributes.custom_attributes is not None:
+    h = {}
+    for k in spec.attributes.custom_attributes.keys():
+        h[f"{ex.name}.{k}"] = spec.attributes.custom_attributes[k]
+    spec.attributes.custom_attributes = h
+
+spec.executable = os.path.expanduser(spec.executable)
+job = Job(spec)
+
+ex.submit(job)
+print(job.native_id)

--- a/spec/job/adapters/psij_spec.rb
+++ b/spec/job/adapters/psij_spec.rb
@@ -1,0 +1,773 @@
+require "spec_helper"
+require "ood_core/job/adapters/psij"
+
+describe OodCore::Job::Adapters::PSIJ do
+  # Required arguments
+  let(:psij) { double() }
+  let(:qstat_factor) { nil }
+
+  # Subject
+  subject(:adapter) { described_class.new(psij: psij) }
+
+  it { is_expected.to respond_to(:submit).with(1).argument.and_keywords(:after, :afterok, :afternotok, :afterany) }
+  it { is_expected.to respond_to(:info_all).with(0).arguments.and_keywords(:attrs) }
+  it { is_expected.to respond_to(:info_where_owner).with(1).argument.and_keywords(:attrs) }
+  it { is_expected.to respond_to(:info).with(1).argument }
+  it { is_expected.to respond_to(:status).with(1).argument }
+  it { is_expected.to respond_to(:hold).with(1).argument }
+  it { is_expected.to respond_to(:release).with(1).argument }
+  it { is_expected.to respond_to(:delete).with(1).argument }
+  it { is_expected.to respond_to(:directive_prefix).with(0).arguments }
+
+  it "claims to support job arrays" do
+    expect(subject.supports_job_arrays?).to be_truthy
+  end
+
+  describe ".new" do
+    context "when :psij not defined" do
+      subject { described_class.new }
+
+      it "raises ArgumentError" do
+        expect { subject }.to raise_error(ArgumentError)
+      end
+    end
+  end
+
+  describe "#submit" do
+    def build_script(opts = {})
+      OodCore::Job::Script.new(
+        **{
+          content: content
+        }.merge(opts)
+      )
+    end
+
+    let(:psij)  { double(submit_job_path: "job.123", executor: "slurm", queue_name:"debug") }
+    let(:content) { "my batch script" }
+
+    context "when script not defined" do
+      it "raises ArgumentError" do
+        expect { adapter.submit }.to raise_error(ArgumentError)
+      end
+    end
+
+    subject { adapter.submit(build_script) }
+
+    it "returns job id" do
+      is_expected.to eq("job.123")
+      expect(psij).to have_received(:submit_job_path).with(args: ["slurm"], chdir: nil, stdin: "{\"executable\":\"~/ood_tmp/run.sh\",\"stdout_path\":\"/home/ohmura/src/ood_core/stdout.txt\",\"stderr_path\":\"/home/ohmura/src/ood_core/stderr.txt\",\"attributes\":{},\"resources\":{\"__version\":1}}")
+    end
+
+    context "with :queue_name" do
+      before { adapter.submit(build_script(queue_name: "queue")) }
+
+      it { expect(psij).to have_received(:submit_job_path).with(args: ["slurm"], chdir: nil, stdin: "{\"executable\":\"~/ood_tmp/run.sh\",\"stdout_path\":\"/home/ohmura/src/ood_core/stdout.txt\",\"stderr_path\":\"/home/ohmura/src/ood_core/stderr.txt\",\"attributes\":{\"queue_name\":\"queue\"},\"resources\":{\"__version\":1}}") }
+    end
+
+    context "with :args" do
+      before { adapter.submit(build_script(args: ["arg1", "arg2"])) }
+
+      it { expect(psij).to have_received(:submit_job_path).with(args: ["slurm"], chdir: nil, stdin: "{\"executable\":\"~/ood_tmp/run.sh\",\"stdout_path\":\"/home/ohmura/src/ood_core/stdout.txt\",\"stderr_path\":\"/home/ohmura/src/ood_core/stderr.txt\",\"attributes\":{\"custom_attributes\":{\"arg1\":\"\",\"arg2\":\"\"}},\"resources\":{\"__version\":1}}") }
+    end
+
+    context "with :submit_as_hold" do
+      context "as true" do
+        before { adapter.submit(build_script(submit_as_hold: true)) }
+
+        it { expect(psij).to have_received(:submit_job_path).with(args: ["slurm"], chdir: nil, stdin: "{\"executable\":\"~/ood_tmp/run.sh\",\"stdout_path\":\"/home/ohmura/src/ood_core/stdout.txt\",\"stderr_path\":\"/home/ohmura/src/ood_core/stderr.txt\",\"attributes\":{},\"resources\":{\"__version\":1}}") }
+      end
+
+      context "as false" do
+        before { adapter.submit(build_script(submit_as_hold: false)) }
+
+        it { expect(psij).to have_received(:submit_job_path).with(args: ["slurm"], chdir: nil, stdin: "{\"executable\":\"~/ood_tmp/run.sh\",\"stdout_path\":\"/home/ohmura/src/ood_core/stdout.txt\",\"stderr_path\":\"/home/ohmura/src/ood_core/stderr.txt\",\"attributes\":{},\"resources\":{\"__version\":1}}") }
+      end
+    end
+
+    context "with :rerunnable" do
+      context "as true" do
+        before { adapter.submit(build_script(rerunnable: true)) }
+
+        it { expect(psij).to have_received(:submit_job_path).with(args: ["slurm"], chdir: nil, stdin: "{\"executable\":\"~/ood_tmp/run.sh\",\"stdout_path\":\"/home/ohmura/src/ood_core/stdout.txt\",\"stderr_path\":\"/home/ohmura/src/ood_core/stderr.txt\",\"attributes\":{},\"resources\":{\"__version\":1}}") }
+      end
+
+      context "as false" do
+        before { adapter.submit(build_script(rerunnable: false)) }
+
+        it { expect(psij).to have_received(:submit_job_path).with(args: ["slurm"], chdir: nil, stdin: "{\"executable\":\"~/ood_tmp/run.sh\",\"stdout_path\":\"/home/ohmura/src/ood_core/stdout.txt\",\"stderr_path\":\"/home/ohmura/src/ood_core/stderr.txt\",\"attributes\":{},\"resources\":{\"__version\":1}}") }
+      end
+    end
+
+    context "with :job_environment" do
+      before { adapter.submit(build_script(job_environment: {"key" => "value"})) }
+
+      it { expect(psij).to have_received(:submit_job_path).with(args: ["slurm"], chdir: nil, stdin: "{\"environment\":{\"key\":\"value\"},\"executable\":\"~/ood_tmp/run.sh\",\"stdout_path\":\"/home/ohmura/src/ood_core/stdout.txt\",\"stderr_path\":\"/home/ohmura/src/ood_core/stderr.txt\",\"attributes\":{},\"resources\":{\"__version\":1}}") }
+    end
+
+    context "with :job_environment and Script#copy_environment is true" do
+      before { adapter.submit(build_script(copy_environment: true, job_environment: {"key" => "value"})) }
+ 
+      it { expect(psij).to have_received(:submit_job_path).with(args: ["slurm"], chdir: nil, stdin: "{\"environment\":{\"key\":\"value\"},\"executable\":\"~/ood_tmp/run.sh\",\"stdout_path\":\"/home/ohmura/src/ood_core/stdout.txt\",\"stderr_path\":\"/home/ohmura/src/ood_core/stderr.txt\",\"inherit_environment\":true,\"attributes\":{},\"resources\":{\"__version\":1}}") }
+    end
+
+    context "with :workdir" do
+      before { adapter.submit(build_script(workdir: "/path/to/workdir")) }
+
+      it { expect(psij).to have_received(:submit_job_path).with(args: ["slurm"], chdir: Pathname.new("/path/to/workdir"), stdin: "{\"directory\":\"/path/to/workdir\",\"executable\":\"~/ood_tmp/run.sh\",\"stdout_path\":\"/home/ohmura/src/ood_core/stdout.txt\",\"stderr_path\":\"/home/ohmura/src/ood_core/stderr.txt\",\"attributes\":{},\"resources\":{\"__version\":1}}") }
+    end
+
+    context "with :email" do
+      before { adapter.submit(build_script(email: ["email1", "email2"])) }
+
+      it { expect(psij).to have_received(:submit_job_path).with(args: ["slurm"], chdir: nil, stdin: "{\"executable\":\"~/ood_tmp/run.sh\",\"stdout_path\":\"/home/ohmura/src/ood_core/stdout.txt\",\"stderr_path\":\"/home/ohmura/src/ood_core/stderr.txt\",\"attributes\":{},\"resources\":{\"__version\":1}}") }
+    end
+
+    context "with :email_on_started" do
+      context "as true" do
+        before { adapter.submit(build_script(email_on_started: true)) }
+
+        it { expect(psij).to have_received(:submit_job_path).with(args: ["slurm"], chdir: nil, stdin: "{\"executable\":\"~/ood_tmp/run.sh\",\"stdout_path\":\"/home/ohmura/src/ood_core/stdout.txt\",\"stderr_path\":\"/home/ohmura/src/ood_core/stderr.txt\",\"attributes\":{},\"resources\":{\"__version\":1}}") }
+      end
+
+      context "as false" do
+        before { adapter.submit(build_script(email_on_started: false)) }
+
+        it { expect(psij).to have_received(:submit_job_path).with(args: ["slurm"], chdir: nil, stdin: "{\"executable\":\"~/ood_tmp/run.sh\",\"stdout_path\":\"/home/ohmura/src/ood_core/stdout.txt\",\"stderr_path\":\"/home/ohmura/src/ood_core/stderr.txt\",\"attributes\":{},\"resources\":{\"__version\":1}}") }
+      end
+    end
+
+    context "with :email_on_terminated" do
+      context "as true" do
+        before { adapter.submit(build_script(email_on_terminated: true)) }
+
+        it { expect(psij).to have_received(:submit_job_path).with(args: ["slurm"], chdir: nil, stdin: "{\"executable\":\"~/ood_tmp/run.sh\",\"stdout_path\":\"/home/ohmura/src/ood_core/stdout.txt\",\"stderr_path\":\"/home/ohmura/src/ood_core/stderr.txt\",\"attributes\":{},\"resources\":{\"__version\":1}}") }
+      end
+
+      context "as false" do
+        before { adapter.submit(build_script(email_on_terminated: false)) }
+
+        it { expect(psij).to have_received(:submit_job_path).with(args: ["slurm"], chdir: nil, stdin: "{\"executable\":\"~/ood_tmp/run.sh\",\"stdout_path\":\"/home/ohmura/src/ood_core/stdout.txt\",\"stderr_path\":\"/home/ohmura/src/ood_core/stderr.txt\",\"attributes\":{},\"resources\":{\"__version\":1}}") }
+      end
+    end
+
+    context "with :email_on_started and :email_on_terminated" do
+      before { adapter.submit(build_script(email_on_started: true, email_on_terminated: true)) }
+
+      it { expect(psij).to have_received(:submit_job_path).with(args: ["slurm"], chdir: nil, stdin: "{\"executable\":\"~/ood_tmp/run.sh\",\"stdout_path\":\"/home/ohmura/src/ood_core/stdout.txt\",\"stderr_path\":\"/home/ohmura/src/ood_core/stderr.txt\",\"attributes\":{},\"resources\":{\"__version\":1}}") }
+    end
+
+    context "with :job_name" do
+      before { adapter.submit(build_script(job_name: "my_job")) }
+
+      it { expect(psij).to have_received(:submit_job_path).with(args: ["slurm"], chdir: nil, stdin: "{\"name\":\"my_job\",\"executable\":\"~/ood_tmp/run.sh\",\"stdout_path\":\"/home/ohmura/src/ood_core/stdout.txt\",\"stderr_path\":\"/home/ohmura/src/ood_core/stderr.txt\",\"attributes\":{},\"resources\":{\"__version\":1}}") }
+    end
+
+    context "with :shell_path" do
+      before { adapter.submit(build_script(shell_path: "/path/to/shell")) }
+
+      it { expect(psij).to have_received(:submit_job_path).with(args: ["slurm"], chdir: nil, stdin: "{\"executable\":\"~/ood_tmp/run.sh\",\"stdout_path\":\"/home/ohmura/src/ood_core/stdout.txt\",\"stderr_path\":\"/home/ohmura/src/ood_core/stderr.txt\",\"attributes\":{},\"resources\":{\"__version\":1}}") }
+    end
+
+    context "with :input_path" do
+      before { adapter.submit(build_script(input_path: "/path/to/input")) }
+
+      it { expect(psij).to have_received(:submit_job_path).with(args: ["slurm"], chdir: nil, stdin: "{\"executable\":\"~/ood_tmp/run.sh\",\"stdin_path\":\"/path/to/input\",\"stdout_path\":\"/home/ohmura/src/ood_core/stdout.txt\",\"stderr_path\":\"/home/ohmura/src/ood_core/stderr.txt\",\"attributes\":{},\"resources\":{\"__version\":1}}") }
+    end
+
+    context "with :output_path" do
+      before { adapter.submit(build_script(output_path: "/path/to/output")) }
+
+      it { expect(psij).to have_received(:submit_job_path).with(args: ["slurm"], chdir: nil, stdin: "{\"executable\":\"~/ood_tmp/run.sh\",\"stdout_path\":\"/path/to/output\",\"stderr_path\":\"/home/ohmura/src/ood_core/stderr.txt\",\"attributes\":{},\"resources\":{\"__version\":1}}") }
+    end
+
+    context "with :error_path" do
+      before { adapter.submit(build_script(error_path: "/path/to/error")) }
+
+      it { expect(psij).to have_received(:submit_job_path).with(args: ["slurm"], chdir: nil, stdin: "{\"executable\":\"~/ood_tmp/run.sh\",\"stdout_path\":\"/home/ohmura/src/ood_core/stdout.txt\",\"stderr_path\":\"/path/to/error\",\"attributes\":{},\"resources\":{\"__version\":1}}") }
+    end
+
+    context "with :reservation_id" do
+      before { adapter.submit(build_script(reservation_id: "my_rsv")) }
+
+      it { expect(psij).to have_received(:submit_job_path).with(args: ["slurm"], chdir: nil, stdin: "{\"executable\":\"~/ood_tmp/run.sh\",\"stdout_path\":\"/home/ohmura/src/ood_core/stdout.txt\",\"stderr_path\":\"/home/ohmura/src/ood_core/stderr.txt\",\"attributes\":{\"reservation_id\":\"my_rsv\"},\"resources\":{\"__version\":1}}") }
+    end
+
+    context "with :priority" do
+      before { adapter.submit(build_script(priority: 123)) }
+
+      it { expect(psij).to have_received(:submit_job_path).with(args: ["slurm"], chdir: nil, stdin: "{\"executable\":\"~/ood_tmp/run.sh\",\"stdout_path\":\"/home/ohmura/src/ood_core/stdout.txt\",\"stderr_path\":\"/home/ohmura/src/ood_core/stderr.txt\",\"attributes\":{},\"resources\":{\"__version\":1}}") }
+    end
+
+    context "with :start_time" do
+      before { adapter.submit(build_script(start_time: Time.new(2016, 11, 8, 13, 53, 54).to_i)) }
+
+      it { expect(psij).to have_received(:submit_job_path).with(args: ["slurm"], chdir: nil, stdin: "{\"executable\":\"~/ood_tmp/run.sh\",\"stdout_path\":\"/home/ohmura/src/ood_core/stdout.txt\",\"stderr_path\":\"/home/ohmura/src/ood_core/stderr.txt\",\"attributes\":{},\"resources\":{\"__version\":1}}") }
+    end
+
+    context "with :accounting_id" do
+      before { adapter.submit(build_script(accounting_id: "my_account")) }
+
+      it { expect(psij).to have_received(:submit_job_path).with(args: ["slurm"], chdir: nil, stdin: "{\"executable\":\"~/ood_tmp/run.sh\",\"stdout_path\":\"/home/ohmura/src/ood_core/stdout.txt\",\"stderr_path\":\"/home/ohmura/src/ood_core/stderr.txt\",\"attributes\":{\"account\":\"my_account\"},\"resources\":{\"__version\":1}}") }
+    end
+
+    context "with :wall_time" do
+      before { adapter.submit(build_script(wall_time: 94534)) }
+
+      it { expect(psij).to have_received(:submit_job_path).with(args: ["slurm"], chdir: nil, stdin: "{\"executable\":\"~/ood_tmp/run.sh\",\"stdout_path\":\"/home/ohmura/src/ood_core/stdout.txt\",\"stderr_path\":\"/home/ohmura/src/ood_core/stderr.txt\",\"attributes\":{\"duration\":94534},\"resources\":{\"__version\":1}}") }
+    end
+
+    context "with :native" do
+      before { adapter.submit(build_script(native: ["--AAA", "B", "-C", "DDD", "--EEE", "--FFF"])) }
+
+      it { expect(psij).to have_received(:submit_job_path).with(args: ["slurm"], chdir: nil, stdin: "{\"executable\":\"~/ood_tmp/run.sh\",\"stdout_path\":\"/home/ohmura/src/ood_core/stdout.txt\",\"stderr_path\":\"/home/ohmura/src/ood_core/stderr.txt\",\"attributes\":{\"custom_attributes\":{\"AAA\":\"B\",\"C\":\"DDD\",\"EEE\":\"\",\"FFF\":\"\"}},\"resources\":{\"__version\":1}}") }
+    end
+
+    %i(after afterok afternotok afterany).each do |after|
+      context "and :#{after} is defined as a single job id" do
+        before { adapter.submit(build_script, after => "job_id") }
+
+        it { expect(psij).to have_received(:submit_job_path).with(args: ["slurm"], chdir: nil, stdin: "{\"executable\":\"~/ood_tmp/run.sh\",\"stdout_path\":\"/home/ohmura/src/ood_core/stdout.txt\",\"stderr_path\":\"/home/ohmura/src/ood_core/stderr.txt\",\"attributes\":{},\"resources\":{\"__version\":1}}") }
+      end
+
+      context "and :#{after} is defined as multiple job ids" do
+        before { adapter.submit(build_script, after => ["job1", "job2"]) }
+
+        it { expect(psij).to have_received(:submit_job_path).with(args: ["slurm"], chdir: nil, stdin: "{\"executable\":\"~/ood_tmp/run.sh\",\"stdout_path\":\"/home/ohmura/src/ood_core/stdout.txt\",\"stderr_path\":\"/home/ohmura/src/ood_core/stderr.txt\",\"attributes\":{},\"resources\":{\"__version\":1}}") }
+      end
+    end
+
+    context "when OodCore::Job::Adapters::PSIJ::Batch::Error is raised" do
+      before { expect(psij).to receive(:submit_job_path).and_raise(OodCore::Job::Adapters::PSIJ::Batch::Error) }
+
+      it "raises OodCore::JobAdapterError" do
+        expect { subject }.to raise_error(OodCore::JobAdapterError)
+      end
+    end
+  end
+
+  describe "#info_all" do
+    let(:psij) { double(get_jobs: {}) }
+    subject { adapter.info_all }
+
+    it "returns an array of all the jobs" do
+      is_expected.to eq([])
+      expect(psij).to have_received(:get_jobs).with(no_args)
+    end
+
+    context "when OodCore::Job::Adapters::PSIJ::Batch::Error is raised" do
+      before { expect(psij).to receive(:get_jobs).and_raise(OodCore::Job::Adapters::PSIJ::Batch::Error) }
+
+      it "raises OodCore::JobAdapterError" do
+        expect { subject }.to raise_error(OodCore::JobAdapterError)
+      end
+    end
+  end
+
+  describe "#info_where_owner" do
+    let(:job_owner) { "job_owner" }
+    let(:psij) { double(get_jobs: job_ids) }
+    subject { adapter.info_where_owner(job_owner) }
+
+    context "owner has no jobs" do
+      let(:job_ids) { [] }
+
+      it { is_expected.to eq([]) }
+    end
+
+    context "when given list of owners" do
+      let(:job_ids) { [] }
+      let(:job_owner) { ["job_owner_1", "job_owner_2"] }
+
+      it "uses comma delimited owner list" do
+        expect(psij).to receive(:get_jobs).with({owner: job_owner.join(",")})
+        is_expected.to eq([])
+      end
+    end
+
+    context "when owner has multiple jobs" do
+      let(:job_ids) { [ "job_id_1", "job_id_2" ] }
+      let(:psij)   { double(get_jobs: [job_hash_1, job_hash_2], executor:"slurm") }
+      let(:job_hash_1) {
+        {
+          :native_id=>"job_id_1",
+          :owner=>"#{job_owner}",
+          :current_state=>"QUEUED",
+        }
+      }
+      let(:job_hash_2) {
+        {
+          :native_id=>"job_id_2",
+          :owner=>"#{job_owner}",
+          :current_state=>"QUEUED",
+        }
+      }
+
+      before do
+        allow(psij).to receive(:get_jobs).with(id: "job_id_1").and_return([job_hash_1])
+        allow(psij).to receive(:get_jobs).with(id: "job_id_2").and_return([job_hash_2])
+      end
+
+      it "returns list of OodCore::Job::Info objects" do
+        is_expected.to eq([
+          OodCore::Job::Info.new(
+            :id=>"job_id_1",
+            :job_owner=>job_owner,
+            :submit_host=>nil,
+            :status=>:queued,
+            :procs=>0,
+            :accounting_id=>nil,
+            :queue_name=>nil,
+            :wallclock_time=>nil,
+            :wallclock_limit=>nil,
+            :cpu_time=>nil,
+            :submission_time=>nil,
+            :dispatch_time=>nil,
+            :allocated_nodes=>[{:name=>"", :procs=>nil, :features=>[]}],
+            :job_name=>nil,
+            :native=>job_hash_1
+          ),
+          OodCore::Job::Info.new(
+            :id=>"job_id_2",
+            :job_owner=>job_owner,
+            :submit_host=>nil,
+            :status=>:queued,
+            :procs=>0,
+            :accounting_id=>nil,
+            :queue_name=>nil,
+            :wallclock_time=>nil,
+            :wallclock_limit=>nil,
+            :cpu_time=>nil,
+            :submission_time=>nil,
+            :dispatch_time=>nil,
+            :allocated_nodes=>[{:name=>"", :procs=>nil, :features=>[]}],
+            :job_name=>nil,
+            :native=>job_hash_2
+          )
+        ])
+      end
+
+      context "and when OodCore::Job::Adapters::PSIJ::Batch::Error is raised" do
+        let(:psij)  { double(get_jobs: [], executor: "slurm") }
+        let(:msg) { "random error" }
+        before do
+          expect(psij).to receive(:get_jobs).and_raise(OodCore::Job::Adapters::PSIJ::Batch::Error, msg)
+        end
+
+        it "raises OodCore::JobAdapterError" do
+          expect { subject }.to raise_error(OodCore::JobAdapterError)
+        end
+      end
+    end
+  end
+
+  describe "#info" do
+    context "when id is not defined" do
+      it "raises ArgumentError" do
+        expect { adapter.info }.to raise_error(ArgumentError)
+      end
+    end
+
+    let(:job_id)   { "job_id" }
+    let(:job_hash) { {} }
+    let(:psij)   { double(get_jobs: [job_hash], executor:"slurm") }
+    subject { adapter.info(double(to_s: job_id)) }
+
+    context "when job is not running" do
+      let(:job_hash) {
+        {
+          :resourcelist=> {},
+          :native_id=>job_id,
+          :name=>"be_5",
+          :owner=>"trzask",
+          :current_state=>"QUEUED",
+          :group_name=>"ludwik",
+          :process_count=>14,
+          :queue_name=>"oc_windfall",
+          :wall_time=>nil,
+          :duration=>864000,
+          :cpu_time=>nil,
+          :submission_time=>"Fri Jun 23 06:31:33 2017",
+          :dispatch_time=>nil,
+          :submit_host=>"login3.cm.cluster",
+          :account=>nil
+        }
+      }
+
+      it "returns correct OodCore::Job::Info object" do
+        is_expected.to eq(OodCore::Job::Info.new(
+          :id=>job_id,
+          :status=>:queued,
+          :allocated_nodes=>[
+            {:name=>""},
+          ],
+          :submit_host=>"login3.cm.cluster",
+          :job_name=>"be_5",
+          :job_owner=>"trzask",
+          :accounting_id=>nil,
+          :procs=>14,
+          :queue_name=>"oc_windfall",
+          :wallclock_time=>nil,
+          :wallclock_limit=>864000,
+          :cpu_time=>nil,
+          :submission_time=>Time.parse("Fri Jun 23 06:31:33 2017"),
+          :dispatch_time=>nil,
+          :native=>job_hash
+        ))
+      end
+    end
+
+    context "when job is running" do
+      let(:job_hash) {
+        {
+          :resourcelist=> [
+               {:name=>"i15n12", :procs=>28},
+               {:name=>"i15n13", :procs=>28}
+          ],
+          :native_id=>job_id,
+          :name=>"WT_tnc-Z08_eq",
+          :owner=>"lszatkowski",
+          :current_state=>"ACTIVE",
+          :group_name=>"ludwik",
+          :process_count=>56,
+          :queue_name=>"oc_high_pri",
+          :wall_time=>205742,
+          :duration=>691200,
+          :cpu_time=>5,
+          :submission_time=>"Tue Jun 20 21:23:59 2017",
+          :dispatch_time=>"Tue Jun 20 21:24:47 2017",
+          :submit_host=>"login3.cm.cluster",
+          :accounting_id=>nil
+        }
+      }
+
+      it "returns correct OodCore::Job::Info object" do
+        is_expected.to eql(OodCore::Job::Info.new(
+          :id=>job_id,
+          :status=>:running,
+          :allocated_nodes=>[
+            {:name=>"i15n12", :procs=>28},
+            {:name=>"i15n13", :procs=>28}
+          ],
+          :submit_host=>"login3.cm.cluster",
+          :job_name=>"WT_tnc-Z08_eq",
+          :job_owner=>"lszatkowski",
+          :accounting_id=>nil,
+          :procs=>56,
+          :queue_name=>"oc_high_pri",
+          :wallclock_time=>205742,
+          :wallclock_limit=>691200,
+          :cpu_time=>5,
+          :submission_time=>Time.parse("Tue Jun 20 21:23:59 2017"),
+          :dispatch_time=>Time.parse("Tue Jun 20 21:24:47 2017"),
+          :native=>job_hash
+        ))
+      end
+    end
+
+    context "when can't find job" do
+      let(:psij) { double(get_jobs: []) }
+
+      it "returns completed OodCore::Job::Info object" do
+        is_expected.to eq(OodCore::Job::Info.new(id: job_id, status: :completed))
+      end
+    end
+
+    context "when OodCore::Job::Adapters::PSIJ::Batch::Error is raised" do
+      let(:msg) { "random error" }
+      before { expect(psij).to receive(:get_jobs).and_raise(OodCore::Job::Adapters::PSIJ::Batch::Error, msg) }
+
+      it "raises OodCore::JobAdapterError" do
+        expect { subject }.to raise_error(OodCore::JobAdapterError)
+      end
+
+      context "due to invalid job id" do
+        let(:msg) { "Invalid job id specified\n" }
+
+        it "returns completed OodCore::Job::Info object" do
+          is_expected.to eq(OodCore::Job::Info.new(id: job_id, status: :completed))
+        end
+      end
+    end
+
+    context "when user has a . in the name" do
+      # exact same test as 'when job is running' context, but the user (Job_Owner)
+      # is trzask.lastname@login3.cm.cluster instead of just trzask@login3.cm.cluster
+      let(:job_hash) {
+        {
+          :resourcelist=> {},
+          :native_id=>job_id,
+          :name=>"be_5",
+          :owner=>"trzask.lastname",
+          :current_state=>"QUEUED",
+          :group_name=>"ludwik",
+          :process_count=>14,
+          :queue_name=>"oc_windfall",
+          :wallclock=>nil,
+          :duration=>864000,
+          :cpu_time=>nil,
+          :submission_time=>"Fri Jun 23 06:31:33 2017",
+          :dispatch_time=>nil,
+          :submit_host=>"login3.cm.cluster",
+          :accounting_id=>nil
+        }
+      }
+
+      it "returns correct OodCore::Job::Info object" do
+        is_expected.to eq(OodCore::Job::Info.new(
+          :id=>job_id,
+          :status=>:queued,
+          :allocated_nodes=>[
+            {:name=>""},
+          ],
+          :submit_host=>"login3.cm.cluster",
+          :job_name=>"be_5",
+          :job_owner=>"trzask.lastname",
+          :accounting_id=>nil,
+          :procs=>14,
+          :queue_name=>"oc_windfall",
+          :wallclock_time=>nil,
+          :wallclock_limit=>864000,
+          :cpu_time=>nil,
+          :submission_time=>Time.parse("Fri Jun 23 06:31:33 2017"),
+          :dispatch_time=>nil,
+          :native=>job_hash
+        ))
+      end
+    end
+  end
+
+  describe "#status" do
+    context "when id is not defined" do
+      it "raises ArgumentError" do
+        expect { adapter.status }.to raise_error(ArgumentError)
+      end
+    end
+
+    let(:job_state) { "" }
+    let(:job_id)    { "job_id" }
+    let(:psij)    { double(get_jobs: [job_id: job_id, current_state: job_state], executor: "slurm") }
+    subject { adapter.status(double(to_s: job_id)) }
+
+    it "request only job state from OodCore::Job::Adapters::PSIJ::Batch" do
+      subject
+      expect(psij).to have_received(:get_jobs).with(id: job_id)
+    end
+
+    context "when job is in NEW state" do
+      let(:job_state) { "NEW" }
+
+      it { is_expected.to be_undetermined }
+    end
+
+    context "when job is in QUEUED state" do
+      let(:job_state) { "QUEUED" }
+
+      it { is_expected.to be_queued }
+    end
+
+    context "when job is in HELD state" do
+      let(:job_state) { "HELD" }
+
+      it { is_expected.to be_queued_held }
+    end
+
+    context "when job is in ACTIVE state" do
+      let(:job_state) { "ACTIVE" }
+
+      it { is_expected.to be_running }
+    end
+
+    context "when job is in COMPLETED state" do
+      let(:job_state) { "COMPLETED" }
+
+      it { is_expected.to be_completed }
+    end
+
+    context "when OodCore::Job::Adapters::PSIJ::Batch::Error is raised" do
+      let(:msg) { "random error" }
+      before { expect(psij).to receive(:get_jobs).and_raise(OodCore::Job::Adapters::PSIJ::Batch::Error, msg) }
+
+      it "raises OodCore::JobAdapterError" do
+        expect { subject }.to raise_error(OodCore::JobAdapterError)
+      end
+
+      context "due to invalid job id" do
+        let(:msg) { "Invalid job id specified\n" }
+
+        it { is_expected.to be_completed }
+      end
+    end
+  end
+
+  describe "#hold" do
+    context "when id is not defined" do
+      it "raises ArgumentError" do
+        expect { adapter.hold }.to raise_error(ArgumentError)
+      end
+    end
+
+    let(:job_id) { "job_id" }
+    let(:psij)  { double(hold_job: nil, executor: "slurm") }
+    subject { adapter.hold(double(to_s: job_id)) }
+
+    it "holds job using OodCore::Job::Adapters::PSIJ::Batch" do
+      subject
+      expect(psij).to have_received(:hold_job).with({:args=>["--id=job_id", "--executor=slurm"]})
+    end
+
+    context "when OodCore::Job::Adapters::PSIJ::Batch::Error is raised" do
+      let(:msg) { "random error" }
+      before { expect(psij).to receive(:hold_job).and_raise(OodCore::Job::Adapters::PSIJ::Batch::Error, msg) }
+
+      it "raises OodCore::JobAdapterError" do
+        expect { subject }.to raise_error(OodCore::JobAdapterError)
+      end
+
+      context "due to invalid job id" do
+        let(:msg) { "Invalid job id specified\n" }
+
+        it { is_expected.to be_nil }
+      end
+    end
+  end
+
+  describe "#release" do
+    context "when id is not defined" do
+      it "raises ArgumentError" do
+        expect { adapter.release }.to raise_error(ArgumentError)
+      end
+    end
+
+    let(:job_id) { "job_id" }
+    let(:psij)  { double(release_job: nil, executor:"slurm") }
+    subject { adapter.release(double(to_s: job_id)) }
+
+    it "releases job using OodCore::Job::Adapters::PSIJ::Batch" do
+      subject
+      expect(psij).to have_received(:release_job).with({:args=>["--id=job_id", "--executor=slurm"]})
+    end
+
+    context "when OodCore::Job::Adapters::PSIJ::Batch::Error is raised" do
+      let(:msg) { "random error" }
+      before { expect(psij).to receive(:release_job).and_raise(OodCore::Job::Adapters::PSIJ::Batch::Error, msg) }
+
+      it "raises OodCore::JobAdapterError" do
+        expect { subject }.to raise_error(OodCore::JobAdapterError)
+      end
+
+      context "due to invalid job id" do
+        let(:msg) { "Invalid job id specified\n" }
+
+        it { is_expected.to be_nil }
+      end
+    end
+  end
+
+  describe "#delete" do
+    context "when id is not defined" do
+      it "raises ArgumentError" do
+        expect { adapter.delete }.to raise_error(ArgumentError)
+      end
+    end
+
+    let(:job_id) { "job_id" }
+    let(:psij) { double(delete_job: nil, executor: "slurm") }
+    subject { adapter.delete(double(to_s: job_id)) }
+
+    it "deletes job using OodCore::Job::Adapters::PSIJ::Batch" do
+      subject
+      expect(psij).to have_received(:delete_job).with({:args=>["--id=job_id", "--executor=slurm"]})
+    end
+
+    context "when OodCore::Job::Adapters::PSIJ::Batch::Error is raised" do
+      let(:msg) { "random error" }
+      before { expect(psij).to receive(:delete_job).and_raise(OodCore::Job::Adapters::PSIJ::Batch::Error, msg) }
+
+      it "raises OodCore::JobAdapterError" do
+        expect { subject }.to raise_error(OodCore::JobAdapterError)
+      end
+
+      context "due to invalid job id" do
+        let(:msg) { "Invalid job id specified\n" }
+
+        it { is_expected.to be_nil }
+      end
+    end
+  end
+
+  describe "customizing bin paths" do
+    let(:script) { OodCore::Job::Script.new(content: "echo 'hi'") }
+
+    context "when calling with no config" do
+      it "uses correct command" do
+        batch = OodCore::Job::Adapters::PSIJ::Batch.new(cluster: "owens.osc.edu", conf: nil, bin_overrides: {})
+        allow(Open3).to receive(:capture3).and_return(["job.123", "", double("success?" => true)])
+
+        OodCore::Job::Adapters::PSIJ.new(psij: batch).submit script
+        expect(Open3).to have_received(:capture3).with(anything, "python3", any_args)
+      end
+    end
+
+    context "when calling with normal config" do
+      it "uses the correct command" do
+        batch = OodCore::Job::Adapters::PSIJ::Batch.new(cluster: "owens.osc.edu", conf: "/etc/slurm.conf", bin_overrides: {})
+        allow(Open3).to receive(:capture3).and_return(["job.123", "", double("success?" => true)])
+
+        OodCore::Job::Adapters::PSIJ.new(psij: batch).submit script
+        expect(Open3).to have_received(:capture3).with(anything, "python3", any_args)
+      end
+    end
+
+    context "when calling with overrides" do
+      it "uses the correct command" do
+        batch = OodCore::Job::Adapters::PSIJ::Batch.new(cluster: "owens.osc.edu", conf: "/opt/psij", bin_overrides: {"python3" => "not_python"})
+        allow(Open3).to receive(:capture3).and_return(["job.123", "", double("success?" => true)])
+
+        OodCore::Job::Adapters::PSIJ.new(psij: batch).submit script
+        expect(Open3).to have_received(:capture3).with(anything, "not_python", any_args)
+      end
+    end
+  end
+
+  describe "setting submit_host" do 
+    let(:script) { OodCore::Job::Script.new(content: "echo 'hi'") }
+
+    context "when calling withoug submit_host" do
+      it "uses the correct command" do
+        batch = OodCore::Job::Adapters::PSIJ::Batch.new(cluster: "owens.osc.edu", conf: nil, bin_overrides: {}, submit_host: "")
+        allow(Open3).to receive(:capture3).and_return(["job.123", "", double("success?" => true)])
+
+        OodCore::Job::Adapters::PSIJ.new(psij: batch).submit script
+        expect(Open3).to have_received(:capture3).with(anything, "python3", any_args)
+      end
+    end
+
+    context "when calling with submit_host & strict_host_checking not specified" do 
+      it "uses ssh wrapper & host checking defaults to yes" do
+        batch = OodCore::Job::Adapters::PSIJ::Batch.new(cluster: "owens.osc.edu", conf: nil, bin_overrides: {}, submit_host: "owens.osc.edu")
+        allow(Open3).to receive(:capture3).and_return(["job.123", "", double("success?" => true)])
+
+        OodCore::Job::Adapters::PSIJ.new(psij: batch).submit script
+        expect(Open3).to have_received(:capture3).with(anything,'ssh', '-p', '22', '-o', 'BatchMode=yes', '-o', 'UserKnownHostsFile=/dev/null', '-o', 'StrictHostKeyChecking=yes', 'owens.osc.edu', 'python3', any_args)
+      end
+    end
+
+    context "when strict_host_checking = 'no' && submit_host specified" do
+      it "defaults host checking to no" do
+        batch = OodCore::Job::Adapters::PSIJ::Batch.new(cluster: "owens.osc.edu", conf: nil, bin_overrides: {}, submit_host: "owens.osc.edu", strict_host_checking: false)
+        allow(Open3).to receive(:capture3).and_return(["job.123", "", double("success?" => true)])
+
+        OodCore::Job::Adapters::PSIJ.new(psij: batch).submit script
+        expect(Open3).to have_received(:capture3).with(anything,'ssh', '-p', '22', '-o', 'BatchMode=yes', '-o', 'UserKnownHostsFile=/dev/null', '-o', 'StrictHostKeyChecking=no', 'owens.osc.edu', 'python3', any_args)
+      end
+    end
+  end
+
+  describe "#directive_prefix" do
+      context "when called" do
+        it "does not raise an error" do
+          expect { adapter.directive_prefix }.not_to raise_error
+        end
+      end
+    end
+end


### PR DESCRIPTION
We would like to propose a new adapter to abstract different job schedulers using the Portable Submission Interface for Jobs (PSI/J, https://exaworks.org/psij).
 Currently, OOD requires an adapter for each scheduler to be implemented and maintained. To simplify the implementation and reduce maintenance costs, this new adapter allows OOD to interact with different job schedulers through a unified interface using PSI/J.
Since PSI/J currently does not provide hold, release, or info methods, which are necessary for OOD, we are submitting a pull request to PSI/J to implement these methods.
 Once this request is approved, we plan to update the documentation with more details.
We would appreciate the opportunity to discuss this pull request first.
Below shows a configuration file to use the proposed adapter. The adapter type should be be set to "psij", and the executor should be specified according to the scheduler (https://exaworks.org/psij-python/docs/v/0.9.10/.generated/tree.html#executors).
Example YAML configuration for cluster.d (Slurm example):
```
job:
  adapter: "psij"
    executor: "slurm"
```