### PR TITLE
AllowAccounts negates DenyAccounts

### DIFF
--- a/lib/ood_core/job/adapters/slurm.rb
+++ b/lib/ood_core/job/adapters/slurm.rb
@@ -437,7 +437,11 @@ module OodCore
                                        hsh[:AllowAccounts].to_s.split(',')
                                      end
 
-              hsh[:deny_accounts] = hsh[:DenyAccounts].nil? ? [] : hsh[:DenyAccounts].to_s.split(',')
+              hsh[:deny_accounts] = if !hsh[:allow_accounts].nil?
+                                      nil # manpage says AllowAccounts negates DenyAccounts
+                                    else
+                                      hsh[:DenyAccounts].nil? ? [] : hsh[:DenyAccounts].to_s.split(',')
+                                    end
 
               hsh[:tres] = case hsh[:TRES]
                            when nil, '(null)', ''


### PR DESCRIPTION
https://slurm.schedmd.com/slurm.conf.html#OPT_AllowAccounts

> NOTE: If AllowAccounts is used then DenyAccounts will not be enforced.