### PR TITLE
remove `qos` attribute from `QueueInfo`

### DIFF
--- a/lib/ood_core/job/adapters/slurm.rb
+++ b/lib/ood_core/job/adapters/slurm.rb
@@ -430,7 +430,6 @@ module OodCore
               end.to_h.symbolize_keys
 
               hsh[:name] = hsh[:PartitionName]
-              hsh[:qos] =  hsh[:QoS].to_s == 'N/A' ? [] : hsh[:QoS].to_s.split(',')
               hsh[:allow_accounts] = if hsh[:AllowAccounts].nil? || hsh[:AllowAccounts].to_s == 'ALL'
                                        nil
                                      else

--- a/lib/ood_core/job/queue_info.rb
+++ b/lib/ood_core/job/queue_info.rb
@@ -9,9 +9,6 @@ class OodCore::Job::QueueInfo
   attr_reader :name
   alias to_s name
 
-  # The QoSes associated with this queue
-  attr_reader :qos
-
   # The accounts that are allowed to use this queue.
   #
   # nil means ALL accounts are allowed.

--- a/spec/job/adapters/slurm_spec.rb
+++ b/spec/job/adapters/slurm_spec.rb
@@ -1402,13 +1402,11 @@ describe OodCore::Job::Adapters::Slurm do
         systems_queue = queues.select { |q| q.name == 'systems' }.first
         expect(systems_queue.allow_accounts).to eq(['root', 'pzs0708', 'pzs0710', 'pzs0722'])
         expect(systems_queue.deny_accounts).to eq([])
-        expect(systems_queue.qos).to eq([])
         expect(systems_queue.gpu?).to eq(true)
 
         quick_queue = queues.select { |q| q.name == 'quick' }.first
         expect(quick_queue.allow_accounts).to eq(nil)
         expect(quick_queue.deny_accounts).to eq(quick_deny_accounts)
-        expect(quick_queue.qos).to eq(['quick'])
         expect(quick_queue.gpu?).to eq(false)
 
         gpu_queue = queues.select { |q| q.name == 'gpuserial' }.first
@@ -1442,12 +1440,10 @@ describe OodCore::Job::Adapters::Slurm do
           systems_queue = queues.select { |q| q.name == 'systems' }.first
           expect(systems_queue.allow_accounts).to eq(['ROOT', 'PZS0708', 'PZS0710', 'PZS0722'])
           expect(systems_queue.deny_accounts).to eq([])
-          expect(systems_queue.qos).to eq([])
 
           quick_queue = queues.select { |q| q.name == 'quick' }.first
           expect(quick_queue.allow_accounts).to eq(nil)
           expect(quick_queue.deny_accounts).to eq(quick_deny_accounts)
-          expect(quick_queue.qos).to eq(['quick'])
         end
       end
     end


### PR DESCRIPTION
The definition for `QueueInfo.qos` is "The QoSes associated with this queue", which is a little vague. In Slurm, Partition QOS is a rather niche feature: 

> A QOS can be attached to a partition. This means the partition will have all the same limits as the QOS. This does not associate jobs with the QOS, nor does it give the job any priority or preemption characteristics of the assigned QOS. Jobs may separately request the same QOS or a different QOS to gain those characteristics. However, the Partition QOS limits will override the job's QOS. If the opposite is desired you may configure the job's QOS with Flags=OverPartQOS which will reverse the order of precedence.

`AccountInfo.qos` shows which QOSes the user can use to schedule jobs via that account. `JobInfo.qos` shows which QOS a job is using. `QueueInfo.qos` pertains only to the resource limits being enforced by slurm, and is completely opaque to the user even in the Slurm command line. If OOD is to be a "rosetta stone" and maintain a model of resource management with maximum compatibility, I don't think this should be part of that model.

I can't find any usage of this attribute. Please strike down this PR if I'm just not understanding or if this attribute is important.

note: it's assumed to be a list, but slurm documentation implies that it should be just one QOS. I tried to make slurm barf with `SLURM_CONF=/tmp/slurm.conf.test scontrol show partition foobar`, with multiple QOS for the `foobar` partition in `/tmp/slurm.conf.test`, but it semeed to ignore my file and just print the partition information from production. I don't currently have a containerized slurmctld that I can break, so I'm not sure if multiple partition QOS is an error or not.