### PR TITLE
Fall back to just hostname if hostname doesn't support -A

### DIFF
--- a/lib/ood_core/job/adapters/linux_host/templates/script_wrapper.erb.sh
+++ b/lib/ood_core/job/adapters/linux_host/templates/script_wrapper.erb.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 SSH_HOSTS=(<%= ssh_hosts.join(' ').to_s %>)
-hostnames=`hostname -A`
+hostnames=`hostname -A 2>/dev/null || hostname`
 for host in ${SSH_HOSTS[@]}
 do
     if [[ " ${hostnames[@]} " =~ " ${host} " ]]; then

--- a/lib/ood_core/job/adapters/systemd/templates/script_wrapper.erb.sh
+++ b/lib/ood_core/job/adapters/systemd/templates/script_wrapper.erb.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 SSH_HOSTS=(<%= ssh_hosts.join(' ').to_s %>)
-hostnames=`hostname -A`
+hostnames=`hostname -A 2>/dev/null || hostname`
 for host in ${SSH_HOSTS[@]}
 do
     if [[ " ${hostnames[@]} " =~ " ${host} " ]]; then


### PR DESCRIPTION
Only the [Debian hostname program](https://manpages.debian.org/testing/hostname/hostname.1.en.html) supports the -A option. Other ones like the [net-tools](https://man7.org/linux/man-pages/man1/hostname.1.html) or [coreutils](https://man7.org/linux/man-pages/man1/hostname.1@@coreutils.html) hostname programs don't.