### PR TITLE
add cluster title method

### DIFF
--- a/lib/ood_core/cluster.rb
+++ b/lib/ood_core/cluster.rb
@@ -78,7 +78,13 @@ module OodCore
     end
 
     def title
-      metadata.title || id.to_s&.titleize || id.to_s
+      if !metadata.title.nil?
+        metadata.title
+      elsif id.to_s.respond_to?(:titleize)
+        id.to_s.titleize
+      else
+        id.to_s
+      end
     end
 
     # Metadata that provides extra information about this cluster


### PR DESCRIPTION
Fixes #899. Attempts to access title attribute from metadata, then tries '.titleize' on the id, finally defaulting to returning the plain id. Testing on OSC showed titleize working, as demonstrated in the dashboard rails console:
```rb
irb(main):009> m = OodCore::Cluster.new id:'glen'
=> 
#<OodCore::Cluster:0x000014c554b7e4d0
...
irb(main):010> m.title
=> "Glen"
irb(main):011> m = OodCore::Cluster.new id:'glen', metadata:{title:'Official Glen Cluster'}
=> 
#<OodCore::Cluster:0x000014c555b46408
...
irb(main):012> m.title
=> "Official Glen Cluster"
```