### PR TITLE
Slurm: total_nodes probably shouldn't account for down/unavailable nodes

### DIFF
--- a/lib/ood_core/job/adapters/slurm.rb
+++ b/lib/ood_core/job/adapters/slurm.rb
@@ -124,7 +124,7 @@ module OodCore
             node_cpu_info = call("sinfo", "-aho %F/%D/%C").strip.split('/')
             gres_length = call("sinfo", "-o %G").lines.map(&:strip).map(&:length).max + 2
             gres_lines = call("sinfo", "-ahNO ,nodehost,gres:#{gres_length},gresused:#{gres_length},statelong")
-                         .lines.uniq.reject { |line| line.match?(/maint|drain|down/ig) }.map(&:split)
+                         .lines.uniq.reject { |line| line.match?(/maint|drain|down/i) }.map(&:split)
             ClusterInfo.new(active_nodes: node_cpu_info[0].to_i,
                             total_nodes: (node_cpu_info[3].to_i - node_cpu_info[2].to_i),
                             active_processors: node_cpu_info[5].to_i,


### PR DESCRIPTION
Nodes that are marked as unavailable/down in Slurm, along with their processors, shouldn't be counted in the ``total_nodes`` and ``total_processors`` figure, as this leads to misleading numbers in certain areas such as the System Status, which presents more resources available than there really are.

Have also added "down" (since down nodes are also inaccessible to the user) and changed the string match on ``gres_lines`` done in #916 to ``/ig`` to account for multiple nodes being in one of those states