### PR TITLE
remove "maint" and "drain" nodes which are inaccessible to the user

### DIFF
--- a/lib/ood_core/job/adapters/slurm.rb
+++ b/lib/ood_core/job/adapters/slurm.rb
@@ -124,7 +124,7 @@ module OodCore
             node_cpu_info = call("sinfo", "-aho %A/%D/%C").strip.split('/')
             gres_length = call("sinfo", "-o %G").lines.map(&:strip).map(&:length).max + 2
             gres_lines = call("sinfo", "-ahNO ,nodehost,gres:#{gres_length},gresused:#{gres_length},statelong")
-                         .lines.uniq.reject { |line| line.match?(/maint|drain/i) }.map(&:split))
+                         .lines.uniq.reject { |line| line.match?(/maint|drain/i) }.map(&:split)
             ClusterInfo.new(active_nodes: node_cpu_info[0].to_i,
                             total_nodes: node_cpu_info[2].to_i,
                             active_processors: node_cpu_info[3].to_i,


### PR DESCRIPTION
Currently "maint" and "drain" nodes are included in the calculation for total available nodes. This can lead to there being reported nodes available when none actually are