### PR TITLE
cast to string and rescue generic standard error

### DIFF
--- a/lib/ood_core/job/adapters/slurm.rb
+++ b/lib/ood_core/job/adapters/slurm.rb
@@ -881,8 +881,8 @@ module OodCore
 
         # safely parse date time string, return nil when there are errors.
         def parse_time(date_time)
-          Time.parse(date_time)
-        rescue ArgumentError
+          Time.parse(date_time.to_s)
+        rescue StandardError
           nil
         end
 

--- a/test/job/adapters/slurm_test.rb
+++ b/test/job/adapters/slurm_test.rb
@@ -78,4 +78,9 @@ class TestSlurm < Minitest::Test
     assert_nil(bad_job.submission_time)
     assert_equal(4, jobs.size)
   end
+
+  def test_nil_parse_time
+    adapter = slurm_instance
+    assert_nil(adapter.send(:parse_time, nil))
+  end
 end


### PR DESCRIPTION
Fixes #937 

by casting the input to a string, and rescuing the more generic StandardError. Also provides a test case for the same.