### PR TITLE
Add configuration for issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Ask a Question
+    url: https://discourse.openondemand.org
+    about: Have a question? Ask it on our Discourse forum instead.


### PR DESCRIPTION
adding a config file to direct people to post questions on discourse rather than here.  we do the same on discourse - direct people to open issues here on GitHub for feature requests or bugs.  