### PR TITLE
add a task for looking at an info object

### DIFF
--- a/lib/tasks/slurm.rb
+++ b/lib/tasks/slurm.rb
@@ -14,4 +14,11 @@ namespace :slurm do
 
     puts single_job
   end
+
+  desc 'Print an OodCore::Info job'
+  task :info do
+    require 'json'
+    adapter = OodCore::Job::Factory.build({ adapter: 'slurm' })
+    puts JSON.pretty_generate(adapter.info_all.first.to_h)
+  end
 end


### PR DESCRIPTION
> Please review our [Contributing Guide](https://github.com/OSC/ondemand/blob/main/CONTRIBUTING.md) before submitting a pull request.

## What does this PR do?

Adds a task to print OodCore::Info object in json format.  While reviewing an upstream ondemand request I wondered about the format of certain fields, specifically time fields and how they were formatted. This task helps generate an object to inspect a given fields format.

## Related issue
Does not close any issue.

## Testing
- [ ] Tests included
- [x] No tests needed — reason: it's a rake task

## Checklist
- [x] Follows project code style and conventions
- [ ] Documentation provided *(if new feature, adapter or behavior change)*
- [ ] This is a large feature and was discussed in an issue first *(if applicable)*

## Anything else?
Screenshots, context, or anything reviewers should pay close attention to.
