### PR TITLE
Support Coder deployments that need no cloud credentials

### DIFF
--- a/lib/ood_core/job/adapters/coder.rb
+++ b/lib/ood_core/job/adapters/coder.rb
@@ -10,15 +10,20 @@ module OodCore
       using Refinements::HashExtensions
 
       require "ood_core/job/adapters/coder/openstack_credentials"
+      require "ood_core/job/adapters/coder/no_credentials"
 
       def self.build_coder(config)
         config = config.to_h.symbolize_keys
-        if config[:auth]["cloud"] == "openstack"
+        cloud = config.dig(:auth, "cloud")
+        case cloud
+        when "openstack"
           credentials = OpenStackCredentials.new(config[:auth]["url"], config[:auth]["credentials_dir"]) 
+        when nil, "none"
+          credentials = NoCredentials.new
         else
-          raise ArgumentError, "Unsupported credentials for cloud type: #{config[:auth]['cloud']}"
+          raise ArgumentError, "Unsupported credentials for cloud type: #{cloud}"
         end
-        batch = Adapters::Coder::Batch.new(config.to_h.symbolize_keys, credentials)
+        batch = Adapters::Coder::Batch.new(config, credentials)
         Adapters::Coder.new(batch)
       end
     end

--- a/lib/ood_core/job/adapters/coder.rb
+++ b/lib/ood_core/job/adapters/coder.rb
@@ -10,7 +10,7 @@ module OodCore
       using Refinements::HashExtensions
 
       require "ood_core/job/adapters/coder/openstack_credentials"
-      require "ood_core/job/adapters/coder/no_credentials"
+      require "ood_core/job/adapters/coder/none_credentials"
 
       def self.build_coder(config)
         config = config.to_h.symbolize_keys
@@ -19,7 +19,7 @@ module OodCore
         when "openstack"
           credentials = OpenStackCredentials.new(config[:auth]["url"], config[:auth]["credentials_dir"]) 
         when nil, "none"
-          credentials = NoCredentials.new
+          credentials = NoneCredentials.new
         else
           raise ArgumentError, "Unsupported credentials for cloud type: #{cloud}"
         end

--- a/lib/ood_core/job/adapters/coder/no_credentials.rb
+++ b/lib/ood_core/job/adapters/coder/no_credentials.rb
@@ -1,0 +1,25 @@
+require "ood_core/job/adapters/coder/credentials"
+
+# Credentials implementation for infrastructure that requires no cloud
+# authentication, such as Docker or Kubernetes based Coder templates.
+#
+# The adapter always sends the application credential rich parameters when
+# creating a workspace, and Coder rejects a build if a declared parameter is
+# not supplied, so empty values are returned rather than omitting them.
+class NoCredentials < CredentialsInterface
+  def generate_credentials(project_id = nil)
+    { id: "", name: "", secret: "", user_id: "" }
+  end
+
+  def save_credentials(id, app_credentials)
+    # nothing to persist
+  end
+
+  def load_credentials(id)
+    {}
+  end
+
+  def destroy_credentials(app_credentials, deletion_status, id)
+    # nothing to revoke
+  end
+end

--- a/lib/ood_core/job/adapters/coder/none_credentials.rb
+++ b/lib/ood_core/job/adapters/coder/none_credentials.rb
@@ -6,7 +6,7 @@ require "ood_core/job/adapters/coder/credentials"
 # The adapter always sends the application credential rich parameters when
 # creating a workspace, and Coder rejects a build if a declared parameter is
 # not supplied, so empty values are returned rather than omitting them.
-class NoCredentials < CredentialsInterface
+class NoneCredentials < CredentialsInterface
   def generate_credentials(project_id = nil)
     { id: "", name: "", secret: "", user_id: "" }
   end

--- a/test/job/adapters/coder_test.rb
+++ b/test/job/adapters/coder_test.rb
@@ -66,4 +66,40 @@ class CoderTest < Minitest::Test
 
     assert_equal(80, coder.info('abc-123').ood_connection_info[:port])
   end
+  def test_build_coder_with_cloud_none
+    adapter = OodCore::Job::Factory.build(
+      'adapter' => 'coder',
+      'host' => 'https://coder.example.com',
+      'token' => 'fake-token',
+      'service_user' => 'ood',
+      'auth' => { 'cloud' => 'none' }
+    )
+
+    assert_instance_of(OodCore::Job::Adapters::Coder, adapter)
+  end
+
+  def test_build_coder_without_auth_block
+    adapter = OodCore::Job::Factory.build(
+      'adapter' => 'coder',
+      'host' => 'https://coder.example.com',
+      'token' => 'fake-token',
+      'service_user' => 'ood'
+    )
+
+    assert_instance_of(OodCore::Job::Adapters::Coder, adapter)
+  end
+
+  def test_build_coder_rejects_unknown_cloud
+    error = assert_raises(ArgumentError) do
+      OodCore::Job::Factory.build(
+        'adapter' => 'coder',
+        'host' => 'https://coder.example.com',
+        'token' => 'fake-token',
+        'service_user' => 'ood',
+        'auth' => { 'cloud' => 'not-a-cloud' }
+      )
+    end
+
+    assert_match(/not-a-cloud/, error.message)
+  end
 end


### PR DESCRIPTION
## What does this PR do?

`build_coder` raises `ArgumentError` unless `auth.cloud` is `"openstack"`, so the Coder adapter cannot be used with Docker, Kubernetes, or any other Terraform target that needs no cloud authentication.

This adds a `NoCredentials` implementation of `CredentialsInterface` and accepts `auth.cloud` of `"none"` — or no `auth` block at all. A cluster config with no `auth` block previously raised `NoMethodError`, because `config[:auth]["cloud"]` was called on nil.

Unrecognised cloud types still raise, and the message now includes the offending value.

This follows on from #956 — @andrejcermak asked there what use case I was implementing, and this is it: running Coder workspaces as Docker containers rather than OpenStack VMs.

### Why the credential parameters are still sent as empty strings

`get_rich_parameters` always sends the four application-credential parameters. It would be tidier to omit them when there are no credentials, but I tested this against Coder v2.36.0 and it isn't safe:

- omitting a declared parameter → `400 Unable to validate parameters`, *"Required parameter not provided; parameter value is null"*
- supplying it with an empty string → workspace created successfully

So templates that declare these parameters need them present, and `NoCredentials` returns empty values rather than nothing.

## Related issue

N/A

## Testing

- [x] Tests included

Adds three minitest cases to `test/job/adapters/coder_test.rb`: `cloud: "none"` builds the adapter, a config with no `auth` block builds the adapter, and an unrecognised cloud still raises with the value in the message.

Also tested on a live OnDemand 4.2.3 deployment against Coder v2.36.0 with a Docker-based template: workspaces are created and reachable both with `auth.cloud: "none"` and with the `auth` block omitted entirely.

Full suite passes locally — `rake spec`: 1102 examples, 0 failures; `rake test`: 20 runs, 0 failures.

## Checklist

- [x] Follows project code style and conventions
- [ ] Documentation provided *(if new feature, adapter or behavior change)*
- [ ] This is a large feature and was discussed in an issue first *(if applicable)*

## Anything else?

The OpenStack path is unchanged — `auth.cloud: "openstack"` takes the same branch and constructs the same `OpenStackCredentials` object as before.

I'd be happy to document the `auth.cloud` options and the `coder_output` metadata keys (`floating_ip`, `port`) in ood-documentation if that would be useful — they don't appear to be documented anywhere currently.