### PR TITLE
fix unnecessary string composition

### DIFF
--- a/lib/ood_core/job/adapters/slurm.rb
+++ b/lib/ood_core/job/adapters/slurm.rb
@@ -247,7 +247,7 @@ module OodCore
           #TODO: write some barebones test for this? like 2 options and id or no id
           def squeue_args(id: "", owner: nil, options: [])
             args  = ["--all", "--states=all", "--noconvert"]
-            args.concat ["-O", "#{options.push(nil).join(":#{UNIT_SEPARATOR},")}"]
+            args.concat ["-O", options.push(nil).join(":#{UNIT_SEPARATOR},")]
             args.concat ["-u", owner.to_s] unless owner.to_s.empty?
             args.concat ["-j", id.to_s] unless id.to_s.empty?
             args


### PR DESCRIPTION
## What does this PR do?
Noticed after #954 that these nested double quotes were messing up my syntax highlighting, and after taking a second to think about it I realized this didn't need to be nested at all


## Testing
- [ ] Tests included
- [x] No tests needed — reason: ___

## Checklist
- [x] Follows project code style and conventions
- [ ] Documentation provided *(if new feature, adapter or behavior change)*
- [ ] This is a large feature and was discussed in an issue first *(if applicable)*

## Anything else?
Screenshots, context, or anything reviewers should pay close attention to.
