### PR TITLE
expand queue_info

### DIFF
--- a/lib/ood_core/job/adapters/slurm.rb
+++ b/lib/ood_core/job/adapters/slurm.rb
@@ -486,6 +486,12 @@ module OodCore
                            else
                              hsh[:TRES].to_s.split(',').map { |str| str.split('=') }.to_h
                            end
+
+              hsh[:max_cpus] = hsh[:MaxCPUsPerNode]
+              hsh[:max_nodes] = hsh[:MaxNodes]
+              hsh[:min_nodes] = hsh[:MinNodes]
+              hsh[:max_time] = duration_in_seconds(hsh[:MaxTime])
+
               OodCore::Job::QueueInfo.new(**hsh)
             end
 
@@ -552,6 +558,14 @@ module OodCore
                 }.fetch(a, a)
               }.flatten
             end
+
+          # FIXME: duplicate of the outer class
+          def duration_in_seconds(time)
+            return 0 if time.nil?
+            time, days = time.split("-").reverse
+            days.to_i * 24 * 3600 +
+              time.split(':').map { |v| v.to_i }.inject(0) { |total, v| total * 60 + v }
+          end
         end
 
         # Mapping of state codes for Slurm

--- a/lib/ood_core/job/adapters/slurm.rb
+++ b/lib/ood_core/job/adapters/slurm.rb
@@ -487,9 +487,9 @@ module OodCore
                              hsh[:TRES].to_s.split(',').map { |str| str.split('=') }.to_h
                            end
 
-              hsh[:max_cpus] = hsh[:MaxCPUsPerNode]
-              hsh[:max_nodes] = hsh[:MaxNodes]
-              hsh[:min_nodes] = hsh[:MinNodes]
+              hsh[:max_cpus] = parse_max(hsh[:MaxCPUsPerNode])
+              hsh[:max_nodes] = parse_max(hsh[:MaxNodes])
+              hsh[:min_nodes] = parse_max(hsh[:MinNodes])
               hsh[:max_time] = duration_in_seconds(hsh[:MaxTime])
 
               OodCore::Job::QueueInfo.new(**hsh)
@@ -565,6 +565,12 @@ module OodCore
             time, days = time.split("-").reverse
             days.to_i * 24 * 3600 +
               time.split(':').map { |v| v.to_i }.inject(0) { |total, v| total * 60 + v }
+          end
+
+          def parse_max(max)
+            return nil if max.nil? || max.to_s == 'UNLIMITED'
+
+            max.to_i
           end
         end
 

--- a/lib/ood_core/job/queue_info.rb
+++ b/lib/ood_core/job/queue_info.rb
@@ -24,11 +24,38 @@ class OodCore::Job::QueueInfo
   # An Hash of Trackable Resources and their values.
   attr_reader :tres
 
+  # The minimum nodes a job can request for this queue.
+  # Defaults to nil.
+  # @return [Integer]
+  attr_reader :min_nodes
+
+  # The maximum nodes a job can request for this queue.
+  # Returns nil if unlimited.
+  # @return [Integer]
+  attr_reader :max_nodes
+
+  # The maximum CPUs the job can request. Note these are
+  # minimum per node. Returns nil if unlimited.
+  # @return [Integer]
+  attr_reader :max_cpus
+
+  # The maximum number of time in seconds the job can request.
+  # nil values mean unlimited time or no value was found.
+  # @return [Integer]
+  attr_reader :max_time
+
   def initialize(**opts)
     @name = opts.fetch(:name, 'unknown')
     @allow_qos = opts.fetch(:allow_qos, [])
     @deny_qos = opts.fetch(:deny_qos, [])
     @tres = opts.fetch(:tres, {})
+
+    @max_nodes = parse_max(opts.fetch(:max_nodes, 1))
+    @max_cpus = parse_max(opts.fetch(:max_cpus, 1))
+
+    # these options preserve nil
+    @min_nodes = opts[:min_nodes].to_i if opts[:min_nodes]
+    @max_time = opts[:max_time].to_i if opts[:max_time]
 
     allow_accounts = opts.fetch(:allow_accounts, nil)
     @allow_accounts = if allow_accounts.nil?
@@ -55,5 +82,14 @@ class OodCore::Job::QueueInfo
 
   def allow_all_qos?
     allow_qos.empty? && deny_qos.empty?
+  end
+
+  private
+
+  def parse_max(max)
+    return 1 if max.nil?
+    return nil if max.to_s == 'UNLIMITED'
+
+    max.to_i
   end
 end

--- a/lib/ood_core/job/queue_info.rb
+++ b/lib/ood_core/job/queue_info.rb
@@ -30,17 +30,18 @@ class OodCore::Job::QueueInfo
   attr_reader :min_nodes
 
   # The maximum nodes a job can request for this queue.
-  # Returns nil if unlimited.
+  # Defaults to nil. Can return nil if unlimited.
   # @return [Integer]
   attr_reader :max_nodes
 
   # The maximum CPUs the job can request. Note these are
-  # minimum per node. Returns nil if unlimited.
+  # minimum per node.
+  # Defaults to nil. Can returns nil if unlimited.
   # @return [Integer]
   attr_reader :max_cpus
 
   # The maximum number of time in seconds the job can request.
-  # nil values mean unlimited time or no value was found.
+  # Defaults to nil. Can returns nil if unlimited.
   # @return [Integer]
   attr_reader :max_time
 
@@ -50,12 +51,12 @@ class OodCore::Job::QueueInfo
     @deny_qos = opts.fetch(:deny_qos, [])
     @tres = opts.fetch(:tres, {})
 
-    @max_nodes = parse_max(opts.fetch(:max_nodes, 1))
-    @max_cpus = parse_max(opts.fetch(:max_cpus, 1))
+    @max_nodes = parse_max(opts[:max_nodes])
+    @max_cpus = parse_max(opts[:max_cpus])
+    @max_time = parse_max(opts[:max_time])
 
     # these options preserve nil
     @min_nodes = opts[:min_nodes].to_i if opts[:min_nodes]
-    @max_time = opts[:max_time].to_i if opts[:max_time]
 
     allow_accounts = opts.fetch(:allow_accounts, nil)
     @allow_accounts = if allow_accounts.nil?
@@ -87,8 +88,7 @@ class OodCore::Job::QueueInfo
   private
 
   def parse_max(max)
-    return 1 if max.nil?
-    return nil if max.to_s == 'UNLIMITED'
+    return nil if max.nil? || max.to_s == 'UNLIMITED'
 
     max.to_i
   end

--- a/lib/ood_core/job/queue_info.rb
+++ b/lib/ood_core/job/queue_info.rb
@@ -30,18 +30,18 @@ class OodCore::Job::QueueInfo
   attr_reader :min_nodes
 
   # The maximum nodes a job can request for this queue.
-  # Defaults to nil. Can return nil if unlimited.
+  # Defaults to nil. Returns nil if unlimited.
   # @return [Integer]
   attr_reader :max_nodes
 
   # The maximum CPUs the job can request. Note these are
-  # minimum per node.
-  # Defaults to nil. Can returns nil if unlimited.
+  # maximum per node.
+  # Defaults to nil. Returns nil if unlimited.
   # @return [Integer]
   attr_reader :max_cpus
 
   # The maximum number of time in seconds the job can request.
-  # Defaults to nil. Can returns nil if unlimited.
+  # Defaults to nil. Returns nil if unlimited.
   # @return [Integer]
   attr_reader :max_time
 
@@ -51,12 +51,11 @@ class OodCore::Job::QueueInfo
     @deny_qos = opts.fetch(:deny_qos, [])
     @tres = opts.fetch(:tres, {})
 
-    @max_nodes = parse_max(opts[:max_nodes])
-    @max_cpus = parse_max(opts[:max_cpus])
-    @max_time = parse_max(opts[:max_time])
-
     # these options preserve nil
-    @min_nodes = opts[:min_nodes].to_i if opts[:min_nodes]
+    @min_nodes = opts[:min_nodes] && opts[:min_nodes].to_i
+    @max_nodes = opts[:max_nodes] && opts[:max_nodes].to_i
+    @max_cpus = opts[:max_cpus] && opts[:max_cpus].to_i
+    @max_time = opts[:max_time] && opts[:max_time].to_i
 
     allow_accounts = opts.fetch(:allow_accounts, nil)
     @allow_accounts = if allow_accounts.nil?
@@ -83,13 +82,5 @@ class OodCore::Job::QueueInfo
 
   def allow_all_qos?
     allow_qos.empty? && deny_qos.empty?
-  end
-
-  private
-
-  def parse_max(max)
-    return nil if max.nil? || max.to_s == 'UNLIMITED'
-
-    max.to_i
   end
 end

--- a/test/job/adapters/slurm_test.rb
+++ b/test/job/adapters/slurm_test.rb
@@ -115,4 +115,31 @@ class TestSlurm < Minitest::Test
     refute_nil(queue)
     assert_equal({}, queue.tres)
   end
+
+  def test_queue_info
+    adapter = slurm_instance
+    Open3.stubs(:capture3).with({}, 'scontrol', 'show', 'part', '-o', stdin_data: '')
+         .returns([File.read('spec/fixtures/output/slurm/owens_partitions.txt'), '', exit_success])
+
+    queues = adapter.queues
+    batch = queues.find { |q| q.name == 'batch' }
+    hugemem = queues.find { |q| q.name == 'hugemem' }
+    parallel = queues.find { |q| q.name == 'parallel' }
+
+    assert_nil(batch.max_cpus)
+    assert_equal(48, hugemem.max_cpus)
+    assert_equal(28, parallel.max_cpus)
+
+    assert_nil(batch.max_nodes)
+    assert_equal(1, hugemem.max_nodes)
+    assert_equal(81, parallel.max_nodes)
+
+    assert_equal(0, batch.min_nodes)
+    assert_equal(0, hugemem.min_nodes)
+    assert_equal(2, parallel.min_nodes)
+
+    assert_equal(604_800, batch.max_time)
+    assert_equal(604_800, hugemem.max_time)
+    assert_equal(345_600, parallel.max_time)
+  end
 end

--- a/test/job/queue_info_test.rb
+++ b/test/job/queue_info_test.rb
@@ -13,8 +13,8 @@ class QueueInfoTest < Minitest::Test
     assert_equal([], queue.deny_accounts)
     assert_equal({}, queue.tres)
     assert_nil(queue.min_nodes)
-    assert_equal(1, queue.max_nodes)
-    assert_equal(1, queue.max_cpus)
+    assert_nil(queue.max_nodes)
+    assert_nil(queue.max_cpus)
     assert_nil(queue.max_time)
   end
 end

--- a/test/job/queue_info_test.rb
+++ b/test/job/queue_info_test.rb
@@ -1,0 +1,20 @@
+require 'test_helper'
+
+class QueueInfoTest < Minitest::Test
+  include TestHelper
+
+  def test_defaults
+    queue = OodCore::Job::QueueInfo.new
+
+    assert_equal('unknown', queue.name)
+    assert_equal([], queue.allow_qos)
+    assert_equal([], queue.deny_qos)
+    assert_nil(queue.allow_accounts)
+    assert_equal([], queue.deny_accounts)
+    assert_equal({}, queue.tres)
+    assert_nil(queue.min_nodes)
+    assert_equal(1, queue.max_nodes)
+    assert_equal(1, queue.max_cpus)
+    assert_nil(queue.max_time)
+  end
+end


### PR DESCRIPTION
> Please review our [Contributing Guide](https://github.com/OSC/ondemand/blob/main/CONTRIBUTING.md) before submitting a pull request.

## What does this PR do?

Expands the attributes of the QueueInfo class.

## Related issue
Closes #955

## Testing
- [x] Tests included
- [ ] No tests needed — reason: ___

## Checklist
- [x] Follows project code style and conventions
- [x] Documentation provided *(if new feature, adapter or behavior change)*
- [x] This is a large feature and was discussed in an issue first *(if applicable)*

## Anything else?

* I'm wondering about the `nil` defaults. Specifically around UNLIMITED and not given. I wonder if using `nil` as a default and value (to represent UNLIMITED) is a good idea.
* I'm also wondering if `max_cpus` shouldn't just be `max_cpus_per_node` directly. I think we need to consider how `auto_cores` is going to be used both in batch connect _and_ in the project manager. As in, maybe we need an `auto_cores_per_node` specifically to differentiate the use cases.
* There's also some technical debt around helper methods. For this `duration_in_seconds` is a method in the outer class Slurm, not the inner class Slurm::Batch. I just duplicated it instead of refactoring it, but it should be refactored at some point along with some other maybe class methods.