### PR TITLE
refactor coder credentials to load classes dynamically

### DIFF
--- a/lib/ood_core/job/adapters/coder.rb
+++ b/lib/ood_core/job/adapters/coder.rb
@@ -27,7 +27,7 @@ module OodCore
 
           klass = Object.const_get("#{class_name}Credentials")
           klass.new(**auth.to_h.symbolize_keys)
-        rescue NameError => e
+        rescue NameError
           raise(ArgumentError, "Unsupported credentials for cloud type: #{auth_type.inspect}")
         end
       end

--- a/lib/ood_core/job/adapters/coder.rb
+++ b/lib/ood_core/job/adapters/coder.rb
@@ -14,17 +14,22 @@ module OodCore
 
       def self.build_coder(config)
         config = config.to_h.symbolize_keys
-        cloud = config.dig(:auth, "cloud")
-        case cloud
-        when "openstack"
-          credentials = OpenStackCredentials.new(**config[:auth].to_h.symbolize_keys)
-        when nil, "none"
-          credentials = NoneCredentials.new
-        else
-          raise ArgumentError, "Unsupported credentials for cloud type: #{cloud}"
-        end
+        credentials = build_credentials(config[:auth] || {})
         batch = Adapters::Coder::Batch.new(config, credentials)
         Adapters::Coder.new(batch)
+      end
+
+      def self.build_credentials(auth)
+        begin
+          auth_type = auth.to_h.fetch('cloud', 'none')
+
+          class_name = auth_type.split(/[_-]/).map {|s| s.gsub(/\b\w/, &:upcase) }.join
+
+          klass = Object.const_get("#{class_name}Credentials")
+          klass.new(**auth.to_h.symbolize_keys)
+        rescue NameError => e
+          raise(ArgumentError, "Unsupported credentials for cloud type: #{auth_type.inspect}")
+        end
       end
     end
 

--- a/lib/ood_core/job/adapters/coder.rb
+++ b/lib/ood_core/job/adapters/coder.rb
@@ -17,7 +17,7 @@ module OodCore
         cloud = config.dig(:auth, "cloud")
         case cloud
         when "openstack"
-          credentials = OpenStackCredentials.new(config[:auth]["url"], config[:auth]["credentials_dir"]) 
+          credentials = OpenStackCredentials.new(**config[:auth].to_h.symbolize_keys)
         when nil, "none"
           credentials = NoneCredentials.new
         else

--- a/lib/ood_core/job/adapters/coder.rb
+++ b/lib/ood_core/job/adapters/coder.rb
@@ -28,7 +28,7 @@ module OodCore
           klass = Object.const_get("#{class_name}Credentials")
           klass.new(**auth.to_h.symbolize_keys)
         rescue NameError
-          raise(ArgumentError, "Unsupported credentials for cloud type: #{auth_type.inspect}")
+          raise(ArgumentError, "Unsupported credentials for cloud type: #{auth_type}")
         end
       end
     end

--- a/lib/ood_core/job/adapters/coder/none_credentials.rb
+++ b/lib/ood_core/job/adapters/coder/none_credentials.rb
@@ -7,6 +7,9 @@ require "ood_core/job/adapters/coder/credentials"
 # creating a workspace, and Coder rejects a build if a declared parameter is
 # not supplied, so empty values are returned rather than omitting them.
 class NoneCredentials < CredentialsInterface
+
+  def initialize(**kwargs) end
+
   def generate_credentials(project_id = nil)
     { id: "", name: "", secret: "", user_id: "" }
   end

--- a/lib/ood_core/job/adapters/coder/openstack_credentials.rb
+++ b/lib/ood_core/job/adapters/coder/openstack_credentials.rb
@@ -5,9 +5,9 @@ require "tempfile"
 require 'excon'
 
 class OpenStackCredentials < CredentialsInterface
-  def initialize(auth_url, dir)
-    @auth_url = auth_url
-    @dir = dir
+  def initialize(**kwargs)
+    @auth_url = kwargs[:auth_url]
+    @dir = kwargs[:dir]
   end
 
   def load_credentials(id)

--- a/lib/ood_core/job/adapters/coder/openstack_credentials.rb
+++ b/lib/ood_core/job/adapters/coder/openstack_credentials.rb
@@ -4,7 +4,7 @@ require "ood_core/job/adapters/coder/credentials"
 require "tempfile"
 require 'excon'
 
-class OpenStackCredentials < CredentialsInterface
+class OpenstackCredentials < CredentialsInterface
   def initialize(**kwargs)
     @auth_url = kwargs[:auth_url]
     @dir = kwargs[:dir]

--- a/test/job/adapters/coder_test.rb
+++ b/test/job/adapters/coder_test.rb
@@ -124,7 +124,7 @@ class CoderTest < Minitest::Test
       creds = batch.instance_variable_get(:@credentials)
 
       assert_instance_of(OodCore::Job::Adapters::Coder, adapter)
-      assert_instance_of(OpenStackCredentials, creds)
+      assert_instance_of(OpenstackCredentials, creds)
 
       creds_auth_url = creds.instance_variable_get(:@auth_url)
       creds_dir = creds.instance_variable_get(:@dir)
@@ -153,7 +153,41 @@ class CoderTest < Minitest::Test
 
       assert_instance_of(OodCore::Job::Adapters::Coder, adapter)
       assert_instance_of(NoneCredentials, creds)
+    end
+  end
 
+  def test_new_creds_from_config
+    Dir.mktmpdir do |dir|
+      cfg = <<~HEREDOC
+        ---
+        v2:
+          job:
+            adapter: coder
+            auth:
+              cloud: user_defined_test
+      HEREDOC
+
+      auth = <<~HEREDOC
+        class UserDefinedTestCredentials < CredentialsInterface
+
+          # only need to define the initializer bc that's the only bit being
+          # called in this test
+          def initialize(**kwargs) end
+        end
+      HEREDOC
+
+      Pathname.new("#{dir}/coder.yml").write(cfg)
+      Pathname.new("#{dir}/user_defined_test_credentials.rb").write(auth)
+
+      # credential authors will have to require & load the ruby file in question
+      require "#{dir}/user_defined_test_credentials.rb"
+
+      adapter = OodCore::Clusters.load_file(dir)['coder'].job_adapter
+      batch = adapter.instance_variable_get(:@batch)
+      creds = batch.instance_variable_get(:@credentials)
+
+      assert_instance_of(OodCore::Job::Adapters::Coder, adapter)
+      assert_instance_of(UserDefinedTestCredentials, creds)
     end
   end
 end

--- a/test/job/adapters/coder_test.rb
+++ b/test/job/adapters/coder_test.rb
@@ -66,6 +66,7 @@ class CoderTest < Minitest::Test
 
     assert_equal(80, coder.info('abc-123').ood_connection_info[:port])
   end
+
   def test_build_coder_with_cloud_none
     adapter = OodCore::Job::Factory.build(
       'adapter' => 'coder',
@@ -101,5 +102,58 @@ class CoderTest < Minitest::Test
     end
 
     assert_match(/not-a-cloud/, error.message)
+  end
+
+  def test_openstack_creds_from_config
+    Dir.mktmpdir do |dir|
+      cfg = <<~HEREDOC
+        ---
+        v2:
+          job:
+            adapter: coder
+            auth:
+              cloud: openstack
+              dir: /some/fake/directory
+              auth_url: http://some.auth.url/test
+      HEREDOC
+
+      Pathname.new("#{dir}/coder.yml").write(cfg)
+
+      adapter = OodCore::Clusters.load_file(dir)['coder'].job_adapter
+      batch = adapter.instance_variable_get(:@batch)
+      creds = batch.instance_variable_get(:@credentials)
+
+      assert_instance_of(OodCore::Job::Adapters::Coder, adapter)
+      assert_instance_of(OpenStackCredentials, creds)
+
+      creds_auth_url = creds.instance_variable_get(:@auth_url)
+      creds_dir = creds.instance_variable_get(:@dir)
+
+      assert_equal('http://some.auth.url/test', creds_auth_url)
+      assert_equal('/some/fake/directory', creds_dir)
+    end
+  end
+
+  def test_none_creds_from_config
+    Dir.mktmpdir do |dir|
+      cfg = <<~HEREDOC
+        ---
+        v2:
+          job:
+            adapter: coder
+            auth:
+              cloud: none
+      HEREDOC
+
+      Pathname.new("#{dir}/coder.yml").write(cfg)
+
+      adapter = OodCore::Clusters.load_file(dir)['coder'].job_adapter
+      batch = adapter.instance_variable_get(:@batch)
+      creds = batch.instance_variable_get(:@credentials)
+
+      assert_instance_of(OodCore::Job::Adapters::Coder, adapter)
+      assert_instance_of(NoneCredentials, creds)
+
+    end
   end
 end

--- a/test/job/adapters/coder_test.rb
+++ b/test/job/adapters/coder_test.rb
@@ -165,6 +165,7 @@ class CoderTest < Minitest::Test
             adapter: coder
             auth:
               cloud: user_defined_test
+              test_parameter: 'some new config to test'
       HEREDOC
 
       auth = <<~HEREDOC
@@ -172,7 +173,9 @@ class CoderTest < Minitest::Test
 
           # only need to define the initializer bc that's the only bit being
           # called in this test
-          def initialize(**kwargs) end
+          def initialize(**kwargs) 
+            @test_parameter = kwargs[:test_parameter]
+          end
         end
       HEREDOC
 
@@ -185,9 +188,11 @@ class CoderTest < Minitest::Test
       adapter = OodCore::Clusters.load_file(dir)['coder'].job_adapter
       batch = adapter.instance_variable_get(:@batch)
       creds = batch.instance_variable_get(:@credentials)
+      test_cfg = creds.instance_variable_get(:@test_parameter)
 
       assert_instance_of(OodCore::Job::Adapters::Coder, adapter)
       assert_instance_of(UserDefinedTestCredentials, creds)
+      assert_equal('some new config to test', test_cfg)
     end
   end
 end


### PR DESCRIPTION
> Please review our [Contributing Guide](https://github.com/OSC/ondemand/blob/main/CONTRIBUTING.md) before submitting a pull request.

## What does this PR do?

This changes the way the coder adapter's credentials are loaded so that they can be dynamically loaded at runtime without using a predefined case statement to load them.  That is, users/centers can define these classes then just utilize them without contribution to this library.

## Related issue
Closes #___  *(if applicable)*

## Testing
- [x] Tests included
- [ ] No tests needed — reason: ___

## Checklist
- [x] Follows project code style and conventions
- [ ] Documentation provided *(if new feature, adapter or behavior change)*
- [ ] This is a large feature and was discussed in an issue first *(if applicable)*

## Anything else?

@andrejcermak & @Satyam-Captain FYI