### PR TITLE
Add memory option to script

### DIFF
--- a/lib/ood_core/job/adapters/lsf/helper.rb
+++ b/lib/ood_core/job/adapters/lsf/helper.rb
@@ -92,7 +92,8 @@ class OodCore::Job::Adapters::Lsf::Helper
     args.concat ["-W", (script.wall_time / 60).to_i] unless script.wall_time.nil?
     args.concat ["-L", script.shell_path.to_s] unless script.shell_path.nil?
     args.concat ['-n', script.cores] unless script.cores.nil?
-
+    args.concat ['-M', script.memory] unless script.memory.nil?
+    
     # environment
     env = script.job_environment || {}
     # To preserve pre-existing behavior we only act when true or false, when nil we do nothing

--- a/lib/ood_core/job/adapters/pbspro.rb
+++ b/lib/ood_core/job/adapters/pbspro.rb
@@ -318,6 +318,7 @@ module OodCore
           args.concat ["-a", script.start_time.localtime.strftime("%C%y%m%d%H%M.%S")] unless script.start_time.nil?
           args.concat ["-A", script.accounting_id] unless script.accounting_id.nil?
           args.concat ["-l", "walltime=#{seconds_to_duration(script.wall_time)}"] unless script.wall_time.nil?
+          args.concat ['-l', "mem=#{script.memory}"] unless script.memory.nil?
           args.concat ppn(script)
 
           # Set dependencies

--- a/lib/ood_core/job/adapters/psij.rb
+++ b/lib/ood_core/job/adapters/psij.rb
@@ -373,6 +373,8 @@ module OodCore
             STATE_MAP.fetch(st, :undetermined)
           end
 
+		  # Converts the MiB value from a script object to
+		  # an integer number of bytes required by ResourceSpecV1
 		  def bytes_from_memory(memory)
 			return nil if memory.nil?
 

--- a/lib/ood_core/job/adapters/psij.rb
+++ b/lib/ood_core/job/adapters/psij.rb
@@ -204,6 +204,7 @@ module OodCore
                          duration: script.wall_time,
                          custom_attributes: script.args},
             resources: {__version: 1,
+				        memory: bytes_from_memory(script.memory),
                         gpu_cores_per_process: script.gpus_per_node,
                         cpu_cores_per_process: script.cores}
           }
@@ -371,6 +372,12 @@ module OodCore
           def get_state(st)
             STATE_MAP.fetch(st, :undetermined)
           end
+
+		  def bytes_from_memory(memory)
+			return nil if memory.nil?
+
+			(1_048_576 * memory).to_i
+		  end
 
           def parse_job_info(v)
             # parse input hash to Info object

--- a/lib/ood_core/job/adapters/sge/helper.rb
+++ b/lib/ood_core/job/adapters/sge/helper.rb
@@ -50,6 +50,7 @@ class OodCore::Job::Adapters::Sge::Helper
     args.concat ['-l', "h_rt=" + seconds_to_duration(script.wall_time)] unless script.wall_time.nil?
     args.concat ['-P', script.accounting_id] unless script.accounting_id.nil?
     args.concat ['-t', script.job_array_request] unless script.job_array_request.nil?
+    args.concat ['-l', "mem_free=#{script.memory}M"] unless script.memory.nil?
     args.concat Array.wrap(script.native) if script.native
 
     args

--- a/lib/ood_core/job/adapters/slurm.rb
+++ b/lib/ood_core/job/adapters/slurm.rb
@@ -670,6 +670,7 @@ module OodCore
           args.concat ['--qos', script.qos] unless script.qos.nil?
           args.concat ['--gpus-per-node', script.gpus_per_node] unless script.gpus_per_node.nil?
           args.concat ['-n', script.cores] unless script.cores.nil?
+          args.concat ['--mem', script.memory] unless script.memory.nil?
           # ignore nodes, don't know how to do this for slurm
 
           # Set dependencies

--- a/lib/ood_core/job/adapters/torque.rb
+++ b/lib/ood_core/job/adapters/torque.rb
@@ -160,6 +160,7 @@ module OodCore
             args.concat ['-t', script.job_array_request] unless script.job_array_request.nil?
             args.concat ['-l', "qos=#{script.qos}"] unless script.qos.nil?
             args.concat ['-l', "gpus=#{script.gpus_per_node}"] unless script.gpus_per_node.nil?
+            args.concat ['-l', "mem=#{script.memory}"] unless script.memory.nil? 
             args.concat ppn(script)
 
             # Set environment variables

--- a/lib/ood_core/job/script.rb
+++ b/lib/ood_core/job/script.rb
@@ -112,6 +112,10 @@ module OodCore
       # @return [Integer, nil] cores
       attr_reader :cores
 
+      # The memory request per node, in Mebibytes
+      # @return [Integer, nil] Mebibytes
+      attr_reader :memory
+
       # Object detailing any native specifications that are implementation specific
       # @note Should not be used at all costs.
       # @return [Object, nil] native specifications
@@ -156,7 +160,7 @@ module OodCore
                      queue_name: nil, priority: nil, start_time: nil,
                      wall_time: nil, accounting_id: nil, job_array_request: nil,
                      qos: nil, gpus_per_node: nil, native: nil, copy_environment: nil,
-                     cores: nil, **_)
+                     cores: nil, memory: nil, **_)
         @content = content.to_s
 
         @submit_as_hold      = submit_as_hold
@@ -185,6 +189,7 @@ module OodCore
         @native             = native
         @copy_environment   = (copy_environment.nil?) ? nil : !! copy_environment
         @cores              = cores&.to_i
+        @memory             = memory&.to_i
       end
 
       # Convert object to hash
@@ -216,6 +221,7 @@ module OodCore
           gpus_per_node:       gpus_per_node,
           native:              native,
           cores:               cores,
+          memory:              memory,
           copy_environment:    copy_environment,
         }
       end


### PR DESCRIPTION
## What does this PR do?
Adds a memory option to the script option to request memory-per-node in MiB. Adds support for this attribute in the slurm adapter

## Related issue
Fixes #952 

## Testing
- [ ] Tests included
- [x] No tests needed — reason: ___

## Checklist
- [x] Follows project code style and conventions
- [x] Documentation provided *(if new feature, adapter or behavior change)*
- [x] This is a large feature and was discussed in an issue first *(if applicable)*

## Anything else?
Still exploring documentation for other schedulers, so that will be incoming soon
