### PR TITLE
Refactor `Info#to_h` to derive keys from instance variables

### DIFF
--- a/lib/ood_core/job/info.rb
+++ b/lib/ood_core/job/info.rb
@@ -144,26 +144,10 @@ module OodCore
       # Convert object to hash
       # @return [Hash] object as hash
       def to_h
-        {
-          id:              id,
-          status:          status,
-          allocated_nodes: allocated_nodes,
-          submit_host:     submit_host,
-          job_name:        job_name,
-          job_owner:       job_owner,
-          accounting_id:   accounting_id,
-          procs:           procs,
-          queue_name:      queue_name,
-          wallclock_time:  wallclock_time,
-          wallclock_limit: wallclock_limit,
-          cpu_time:        cpu_time,
-          submission_time: submission_time,
-          dispatch_time:   dispatch_time,
-          native:          native,
-          total_memory:    total_memory,
-          gpus:            gpus,
-          tasks: tasks
-        }
+        instance_variables.map do |ivar|
+          name = ivar.to_s.gsub('@', '').to_sym
+          [name, send(name)]
+        end.to_h
       end
 
       def gpu?

--- a/spec/job/adapters/kubernetes/helper_spec.rb
+++ b/spec/job/adapters/kubernetes/helper_spec.rb
@@ -49,7 +49,7 @@ describe OodCore::Job::Adapters::Kubernetes::Helper do
     dispatch_time: nil,
     submission_time: 1626897251,
     wallclock_time: nil,
-    ood_connection_info: { host: "10.20.0.40" },
+    ood_connection_info: { host: "192.148.247.170" },
     procs: "1"
   }}
 


### PR DESCRIPTION
## What does this PR do?
Replaces the hand-maintained hash literal in `Info#to_h` with the dynamic
`instance_variables` pattern already used by `NodeInfo#to_h`, so new attributes
on `Info` no longer need a matching manual entry in `to_h`.

Also updates `single_running_pod_not_ready_hash` in
`spec/job/adapters/kubernetes/helper_spec.rb` to expect `192.148.247.170`, which
is the `hostIP` in `spec/fixtures/output/k8s/single_running_pod_not_ready.json`.
The previous expectation of `10.20.0.40` did not match that fixture. It went
unnoticed because `ood_connection_info` is a `K8sJobInfo` instance variable, and
the old hand-written `Info#to_h` only listed the parent class's keys — so `==`,
which compares `to_h`, never looked at that field. Three other expectations in
the same file already expect `192.148.247.170`, matching their fixtures.

## Related issue
Closes #962

## Testing
- [x] Tests included
- [ ] No tests needed — reason: ___

Existing coverage: `spec/job/info_spec.rb` `#to_h` block passes unchanged.
Full suite green locally (`bundle exec rake spec`).

## Checklist
- [x] Follows project code style and conventions
- [ ] Documentation provided *(if new feature, adapter or behavior change)* — see note below
- [ ] This is a large feature and was discussed in an issue first *(if applicable)* — N/A

## Anything else?
**There is a behavior change for subclasses, and it's the part worth reviewing.**

`K8sJobInfo` and `CoderJobInfo` both extend `Info` and assign
`@ood_connection_info` after calling `super`. Under the old `to_h` that attribute
was invisible, since the literal only listed the parent's 18 keys. With
`instance_variables` it is now included, which means `to_h`, `==` and `eql?` all
account for it on those two classes.

I think that's the desired behavior, it's what caught the incorrect host
expectation above, but it's a change, so I'm flagging it explicitly.

Two related things I checked but did not change:

- Key order shifts (`tasks` moves earlier, since `@tasks` is assigned before
  `@native`). Ruby hash equality ignores order, so `==` and `eql?` are unaffected.
- `build_child_info` splats `to_h` into a constructor. `Info#initialize` accepts
  `**_`, so the extra subclass key is absorbed without error.
